### PR TITLE
.env example. APP_PORT env variable. rename 'profession' to 'occupation'

### DIFF
--- a/apps/back/.env.dist
+++ b/apps/back/.env.dist
@@ -1,0 +1,4 @@
+APP_PORT=3000
+RESEND_API_KEY=apiKey
+JWT_SECRETS=secrets
+frontUrl=http://localhost:5173

--- a/apps/back/README.md
+++ b/apps/back/README.md
@@ -9,7 +9,7 @@ bun install
 To run:
 
 ```bash
-bun run index.ts
+bun run src/index.ts
 ```
 
 This project was created using `bun init` in bun v1.1.17. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/apps/back/src/demo.ts
+++ b/apps/back/src/demo.ts
@@ -1,21 +1,22 @@
-import { select, input } from '@inquirer/prompts'
-
-import { Civilization } from './simulation/civilization'
-import { Citizen } from './simulation/citizen/citizen'
 import { Resource, ResourceType } from './simulation/resource'
+import { input, select } from '@inquirer/prompts'
+
+import { Citizen } from './simulation/citizen/citizen'
+import { Civilization } from './simulation/civilization'
+import { Gender } from './simulation/citizen/enum'
+import { OccupationType } from './simulation/citizen/work/enum'
 import { World } from './simulation/world'
-import { ProfessionType } from './simulation/citizen/work/enum'
 
 const world = new World()
 const myCivilization = new Civilization()
 
 world.addCivilization(myCivilization)
 
-const alice = new Citizen('Alice', 5, 3)
-const bob = new Citizen('Bob', 2, 3)
+const alice = new Citizen('Alice', 5, Gender.FEMALE, 3)
+const bob = new Citizen('Bob', 2, Gender.MALE, 3)
 
-alice.setProfession(ProfessionType.FARMER)
-bob.setProfession(ProfessionType.CARPENTER)
+alice.setOccupation(OccupationType.FARMER)
+bob.setOccupation(OccupationType.CARPENTER)
 
 // Adding some citizens
 myCivilization.addCitizen(alice)

--- a/apps/back/src/emailTemplates/i-forget.tsx
+++ b/apps/back/src/emailTemplates/i-forget.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 
 import {
   Body,
+  Button,
   Container,
   Head,
+  Heading,
   Html,
   Preview,
   Text,
-  Button,
-  Heading,
 } from '@react-email/components'
 
 interface EmailTemplateProps {
@@ -37,8 +37,8 @@ export const IForgetEmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
           Voici un lien pour réinitialiser votre mot de passe, bon jeu !
         </Text>
         <Button
-          className='box-border w-full rounded-[8px] bg-indigo-600 px-[12px] py-[12px] text-center font-semibold text-white'
-          href={`${Bun.env.fontUrl}/i-forgot?authorizationKey=${authorizationKey}&userId=${userId}`}
+          className="box-border w-full rounded-[8px] bg-indigo-600 px-[12px] py-[12px] text-center font-semibold text-white"
+          href={`${Bun.env.frontUrl}/i-forgot?authorizationKey=${authorizationKey}&userId=${userId}`}
         >
           Réinitialiser mon mot de passe
         </Button>

--- a/apps/back/src/emailTemplates/newUser.tsx
+++ b/apps/back/src/emailTemplates/newUser.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 
 import {
   Body,
+  Button,
   Container,
   Head,
+  Heading,
   Html,
   Preview,
   Text,
-  Button,
-  Heading,
 } from '@react-email/components'
 
 interface EmailTemplateProps {
@@ -28,8 +28,8 @@ export const NewUserEmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
         </Heading>
         <Text>Rejoignez nous dans l'aventure !</Text>
         <Button
-          className='box-border w-full rounded-[8px] bg-indigo-600 px-[12px] py-[12px] text-center font-semibold text-white'
-          href={`${Bun.env.fontUrl}/login`}
+          className="box-border w-full rounded-[8px] bg-indigo-600 px-[12px] py-[12px] text-center font-semibold text-white"
+          href={`${Bun.env.frontUrl}/login`}
         >
           Rejoindre l'aventure
         </Button>

--- a/apps/back/src/index.ts
+++ b/apps/back/src/index.ts
@@ -1,13 +1,13 @@
 import { Elysia } from 'elysia'
-import { version } from '../package.json'
-import { cors } from '@elysiajs/cors'
-import { worldModule } from './modules/world'
-import { logger } from "@bogeychan/elysia-logger"
-import { usersModule } from './modules/users'
-import { civilizationModule } from './modules/civilizations'
-import { swagger } from '@elysiajs/swagger'
 import { authModule } from './modules/auth'
+import { civilizationModule } from './modules/civilizations'
+import { cors } from '@elysiajs/cors'
 import { jwtMiddleware } from './libs/jwt'
+import { logger } from "@bogeychan/elysia-logger"
+import { swagger } from '@elysiajs/swagger'
+import { usersModule } from './modules/users'
+import { version } from '../package.json'
+import { worldModule } from './modules/world'
 
 const app = new Elysia()
   .use(cors())
@@ -22,7 +22,7 @@ const app = new Elysia()
   .use(civilizationModule)
 
 
-app.listen(3000)
+app.listen(process.env.APP_PORT!)
 
 console.log(`🦄 Server started at ${app.server?.url}`)
 

--- a/apps/back/src/modules/civilizations/database.ts
+++ b/apps/back/src/modules/civilizations/database.ts
@@ -1,16 +1,18 @@
-import { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite'
 import { CivilizationEntity, civilizationTable } from '../../../db/schema/civilizations'
+import { and, count, eq, inArray } from 'drizzle-orm'
+
+import { BuildingTypes } from '../../simulation/buildings/enum'
+import { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite'
+import { Citizen } from '../../simulation/citizen/citizen'
 import { Civilization } from '../../simulation/civilization'
 import { CivilizationBuilder } from '../../simulation/builders/civilizationBuilder'
-import { civilizationsResourcesTable } from '../../../db/schema/civilizationsResourcesTable'
-import { and, count, eq, inArray } from 'drizzle-orm'
-import { Resource } from '../../simulation/resource'
-import { BuildingTypes } from '../../simulation/buildings/enum'
+import { Gender } from '../../simulation/citizen/enum'
 import { House } from '../../simulation/buildings/house'
-import { usersCivilizationTable } from '../../../db/schema/usersCivilizationsTable'
+import { Resource } from '../../simulation/resource'
+import { civilizationsResourcesTable } from '../../../db/schema/civilizationsResourcesTable'
 import { civilizationsWorldTable } from '../../../db/schema/civilizationsWorldsTable'
+import { usersCivilizationTable } from '../../../db/schema/usersCivilizationsTable'
 import { worldsTable } from '../../../db/schema/worldSchema'
-import { Citizen } from '../../simulation/citizen/citizen'
 
 export async function buildCivilization(dbClient: BunSQLiteDatabase, civilization: CivilizationEntity): Promise<Civilization> {
   const builder = new CivilizationBuilder()
@@ -29,11 +31,17 @@ export async function buildCivilization(dbClient: BunSQLiteDatabase, civilizatio
     }
   }
 
-  builder.addCitizen(...civilization.citizens.map(({ name, month, lifeCounter, profession, buildingMonthsLeft: buildingYearsLeft, isBuilding }) => {
-    const citizen = new Citizen(name, month, lifeCounter)
-    if (profession) {
-      citizen.setProfession(profession)
+  builder.addCitizen(...civilization.citizens.map(({ name, month, lifeCounter, profession, occupation, buildingMonthsLeft: buildingYearsLeft, isBuilding, gender = Gender.UNKNOWN }) => {
+    const citizen = new Citizen(name, month, gender, lifeCounter)
+    if (occupation) {
+      citizen.setOccupation(occupation)
     }
+
+    // keep it until all civilisations are renewed
+    if (profession) {
+      citizen.setOccupation(profession)
+    }
+
     citizen.isBuilding = isBuilding
     citizen.buildingMonthsLeft = buildingYearsLeft
     return citizen

--- a/apps/back/src/modules/civilizations/index.ts
+++ b/apps/back/src/modules/civilizations/index.ts
@@ -1,21 +1,23 @@
 import Elysia, { error, t } from 'elysia'
-import { CivilizationTable } from './database'
-import { db } from '../../libs/database'
-import { logger } from '@bogeychan/elysia-logger'
-import { jwtMiddleware } from '../../libs/jwt'
-import { CivilizationBuilder } from '../../simulation/builders/civilizationBuilder'
-import { Citizen } from '../../simulation/citizen/citizen'
-import { names, uniqueNamesGenerator } from 'unique-names-generator'
-import { ProfessionType } from '../../simulation/citizen/work/enum'
 import { Resource, ResourceType } from '../../simulation/resource'
+import { names, uniqueNamesGenerator } from 'unique-names-generator'
+
+import { Citizen } from '../../simulation/citizen/citizen'
 import { Civilization } from '../../simulation/civilization'
+import { CivilizationBuilder } from '../../simulation/builders/civilizationBuilder'
+import { CivilizationTable } from './database'
+import { Gender } from '../../simulation/citizen/enum'
+import { OccupationType } from '../../simulation/citizen/work/enum'
 import { authorization } from '../../libs/handlers/authorization'
+import { db } from '../../libs/database'
+import { jwtMiddleware } from '../../libs/jwt'
+import { logger } from '@bogeychan/elysia-logger'
 
 export function formatCivilizations(civilizations: Civilization[]) {
   return civilizations.map((civilization) => ({
     ...civilization,
     citizens: civilization.getCitizens()
-      .map((citizen) => ({ ...citizen, profession: citizen.profession?.professionType, years: citizen.years })),
+      .map((citizen) => ({ ...citizen, occupation: citizen.work?.occupationType, years: citizen.years })),
     resources: civilization.getResources().map((resource) => ({
       type: resource.getType(),
       quantity: resource.getQuantity()
@@ -53,11 +55,11 @@ export const civilizationModule = new Elysia({ prefix: '/civilizations' })
     }
 
     const civilizationBuilder = new CivilizationBuilder()
-    const firstCitizen = new Citizen(uniqueNamesGenerator({ dictionaries: [names] }), 120, 3)
-    const secondCitizen = new Citizen(uniqueNamesGenerator({ dictionaries: [names] }), 120, 3)
+    const firstCitizen = new Citizen(uniqueNamesGenerator({ dictionaries: [names] }), 120, Gender.FEMALE, 3)
+    const secondCitizen = new Citizen(uniqueNamesGenerator({ dictionaries: [names] }), 120, Gender.MALE, 3)
 
-    firstCitizen.setProfession(ProfessionType.FARMER)
-    secondCitizen.setProfession(ProfessionType.CARPENTER)
+    firstCitizen.setOccupation(OccupationType.FARMER)
+    secondCitizen.setOccupation(OccupationType.CARPENTER)
 
     civilizationBuilder
       .withName(body.name)

--- a/apps/back/src/simulation/citizen/citizen.ts
+++ b/apps/back/src/simulation/citizen/citizen.ts
@@ -1,20 +1,23 @@
+import { Carpenter } from './work/carpenter'
+import { Farmer } from './work/farmer'
+import { Gender } from './enum'
+import { OccupationType } from './work/enum'
+import type { Work } from './work/interface'
 // Citizen.ts
 import type { World } from '../world'
-import { Carpenter } from './work/carpenter'
-import { ProfessionType } from './work/enum'
-import { Farmer } from './work/farmer'
-import type { Work } from './work/interface'
 
-const professions = {
-  [ProfessionType.CARPENTER]: Carpenter,
-  [ProfessionType.FARMER]: Farmer
+const works = {
+  [OccupationType.CARPENTER]: Carpenter,
+  [OccupationType.FARMER]: Farmer
 }
 
 export type CitizenEntity = {
   id?: string
   name: string
   month: number
-  profession?: ProfessionType
+  occupation?: OccupationType
+  profession?: OccupationType // keep it until all civilisations are renewed
+  gender: Gender
   lifeCounter: number
   isBuilding: boolean
   buildingMonthsLeft: number
@@ -24,21 +27,23 @@ export type CitizenEntity = {
 export class Citizen {
   name: string
   month: number
-  profession: Work | null = null
+  work: Work | null = null
   lifeCounter: number
   isBuilding: boolean
   buildingMonthsLeft: number
+  gender:  Gender
 
-  constructor(name: string, month: number, lifeCounter: number = 3, isBuilding = false, buildingMonthsLeft = 0) {
+  constructor(name: string, month: number, gender: Gender, lifeCounter: number = 3, isBuilding = false, buildingMonthsLeft = 0) {
     this.name = name
     this.month = month
     this.lifeCounter = lifeCounter
     this.isBuilding = isBuilding
     this.buildingMonthsLeft = buildingMonthsLeft
+    this.gender = gender
   }
 
-  setProfession(professionType: ProfessionType) {
-    this.profession = new professions[professionType]()
+  setOccupation(occupationType: OccupationType) {
+    this.work = new works[occupationType]()
   }
 
   get years() {
@@ -68,11 +73,11 @@ export class Citizen {
   }
 
   collectResource(world: World, amount: number): boolean {
-    if (!this.profession?.canWork(this.years) && !this.isBuilding) {
+    if (!this.work?.canWork(this.years) && !this.isBuilding) {
       return false
     }
 
-    return this.profession?.collectResources(world, amount) ?? false
+    return this.work?.collectResources(world, amount) ?? false
   }
 
   startBuilding(): void {
@@ -91,7 +96,9 @@ export class Citizen {
       lifeCounter: this.lifeCounter,
       month: this.month,
       name: this.name,
-      profession: this.profession?.professionType
+      occupation: this.work?.occupationType,
+      gender: this.gender,
+      
     }
   }
 
@@ -103,7 +110,8 @@ export class Citizen {
       years: this.years,
       month: this.month % 12,
       name: this.name,
-      profession: this.profession?.professionType
+      occupation: this.work?.occupationType,
+      gender: this.gender
     }
 
     if (hint === 'string') {

--- a/apps/back/src/simulation/citizen/enum.ts
+++ b/apps/back/src/simulation/citizen/enum.ts
@@ -1,0 +1,5 @@
+export enum Gender {
+  FEMALE = 'female',
+  MALE = 'male',
+  UNKNOWN = 'unknown'
+}

--- a/apps/back/src/simulation/citizen/work/carpenter.ts
+++ b/apps/back/src/simulation/citizen/work/carpenter.ts
@@ -1,12 +1,12 @@
+import { OccupationType } from './enum'
 import { ResourceType } from '../../resource'
-import type { World } from '../../world'
-import { ProfessionType } from './enum'
 import type { Work } from './interface'
+import type { World } from '../../world'
 
 export class Carpenter implements Work {
 
-  get professionType() {
-    return ProfessionType.CARPENTER
+  get occupationType() {
+    return OccupationType.CARPENTER
   }
 
 

--- a/apps/back/src/simulation/citizen/work/enum.ts
+++ b/apps/back/src/simulation/citizen/work/enum.ts
@@ -1,4 +1,4 @@
-export enum ProfessionType {
+export enum OccupationType {
   FARMER = 'farmer',
   CARPENTER = 'carpenter'
 }

--- a/apps/back/src/simulation/citizen/work/farmer.ts
+++ b/apps/back/src/simulation/citizen/work/farmer.ts
@@ -1,12 +1,12 @@
+import { OccupationType } from './enum'
 import { ResourceType } from '../../resource'
-import type { World } from '../../world'
-import { ProfessionType } from './enum'
 import type { Work } from './interface'
+import type { World } from '../../world'
 
 export class Farmer implements Work {
 
-  get professionType() {
-    return ProfessionType.FARMER
+  get occupationType() {
+    return OccupationType.FARMER
   }
 
   canWork(citizenAge: number): boolean {

--- a/apps/back/src/simulation/citizen/work/interface.ts
+++ b/apps/back/src/simulation/citizen/work/interface.ts
@@ -1,8 +1,8 @@
 import type { World } from '../../world'
-import type { ProfessionType } from './enum'
+import type { OccupationType } from './enum'
 
 export interface Work {
-  get professionType(): ProfessionType
+  get occupationType(): OccupationType
   collectResources(world: World, count: number): boolean
   canWork(citizenAge: number): boolean
 }

--- a/apps/front/.env.example
+++ b/apps/front/.env.example
@@ -1,0 +1,1 @@
+BACK_URL=http://localhost:3000

--- a/apps/front/.gitignore
+++ b/apps/front/.gitignore
@@ -4,7 +4,7 @@
 .svelte-kit
 /package
 .env
-.env.*
+.env.
 !.env.example
 .vercel
 .output

--- a/apps/front/README.md
+++ b/apps/front/README.md
@@ -19,7 +19,7 @@ npm create svelte@latest my-app
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
 
 ```bash
-npm run dev
+bun run dev
 
 # or start the server and open the app in a new browser tab
 npm run dev -- --open

--- a/apps/front/src/lib/components/IconText/icon-text.svelte
+++ b/apps/front/src/lib/components/IconText/icon-text.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	export let iconComponent
+	export let text: string | number
+</script>
+
+<div class="flex items-center">
+	<svelte:component this={iconComponent} />
+	<span class="ml-4">{text}</span>
+</div>

--- a/apps/front/src/routes/my-civilizations/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/+page.svelte
@@ -3,7 +3,8 @@
 	import { Root, Content, Item, Next, Previous } from '$lib/components/ui/carousel'
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card'
 	import { Button, buttonVariants } from '$lib/components/ui/button'
-	import { Landmark, PersonStanding, Plus, Trash } from 'lucide-svelte'
+	import { Carrot, FlameKindling, Landmark, PersonStanding, Plus, Trash, Icon } from 'lucide-svelte'
+
 	import {
 		Dialog,
 		DialogTrigger,
@@ -38,12 +39,19 @@
 		AlertDialogAction
 	} from '$lib/components/ui/alert-dialog'
 	import { Block } from 'konsta/svelte'
+	import IconText from '$lib/components/IconText/icon-text.svelte'
+	import { text } from '@sveltejs/kit'
 
 	export let data: PageData
 
 	const translatedResourceName = {
-		food: 'Nouriture',
+		food: 'Nourriture',
 		wood: 'Bois'
+	}
+
+	const resourceIcons = {
+		food: Carrot,
+		wood: FlameKindling
 	}
 
 	const form = superForm(data.civilizationCreationForm, {
@@ -170,19 +178,19 @@
 					</Button>
 				</span>
 			{:else}
-				<span class="flex items-center">
-					<PersonStanding size="24" />
-					<span class="ml-4">{civilization.citizens.length}</span>
-				</span>
-				<span class="flex items-center">
-					<Landmark size="24" />
-					<span class="ml-4">{civilization.buildings.length}</span>
-				</span>
+				<IconText iconComponent={PersonStanding} text={civilization.citizens.length} />
+				<IconText iconComponent={Landmark} text={civilization.buildings.length} />
+
 				<span>
 					Ressources:
 					<ul>
 						{#each civilization.resources as resource}
-							<li>{translatedResourceName[resource.type]}: {resource.quantity} restante</li>
+							<li>
+								<IconText
+									iconComponent={resourceIcons[resource.type]}
+									text="{translatedResourceName[resource.type]}: {resource.quantity} restante"
+								/>
+							</li>
 						{/each}
 					</ul>
 				</span>

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -2,15 +2,21 @@
 	import { Button } from '$lib/components/ui/button'
 	import type { Citizen } from '../../../types/citizen'
 	import type { PageData } from './$types'
-	import { ArrowLeft } from 'lucide-svelte'
+	import { ArrowLeft, Carrot, FlameKindling } from 'lucide-svelte'
 	import CitizensTable from './datatables/citizens-table.svelte'
 	import { Block } from 'konsta/svelte'
+	import IconText from '$lib/components/IconText/icon-text.svelte'
 
 	export let data: PageData
 
 	const translatedResourceName = {
-		food: 'Nouriture',
+		food: 'Nourriture',
 		wood: 'Bois'
+	}
+
+	const resourceIcons = {
+		food: Carrot,
+		wood: FlameKindling
 	}
 </script>
 
@@ -37,10 +43,13 @@
 		</ul>
 	</span>
 	<span>
-		Resources:
+		Ressources:
 		<ul class="list-inside list-disc">
 			{#each data.civilization.resources as resource}
-				<li>{translatedResourceName[resource.type]}: {resource.quantity} restante</li>
+				<IconText
+					iconComponent={resourceIcons[resource.type]}
+					text="{translatedResourceName[resource.type]}: {resource.quantity}"
+				/>
 			{/each}
 		</ul>
 	</span>

--- a/apps/front/src/routes/my-civilizations/[slug]/datatables/citizens-table.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/datatables/citizens-table.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createTable, Render, Subscribe } from 'svelte-headless-table'
+	import { createRender, createTable, Render, Subscribe } from 'svelte-headless-table'
 	import { readable } from 'svelte/store'
 	import type { Citizen } from '../../../../types/citizen'
 	import {
@@ -10,7 +10,9 @@
 		TableHeader,
 		TableRow
 	} from '$lib/components/ui/table'
-	import { ProfessionType } from '../../../../types/profession'
+	import { OccupationType } from '../../../../types/occupation'
+	import IconText from '../../../../lib/components/IconText/icon-text.svelte'
+	import { Gender } from '@ajustor/civ-api/src/simulation/citizen/enum'
 
 	export let citizens: Citizen[]
 
@@ -22,6 +24,20 @@
 			header: 'Nom'
 		}),
 		table.column({
+			accessor: 'gender',
+			header: 'Genre',
+			cell: ({ value }) => {
+				if (!value) {
+					return ''
+				}
+				return {
+					[Gender.FEMALE]: 'Femme',
+					[Gender.MALE]: 'Homme',
+					[Gender.UNKNOWN]: 'Inconnu'
+				}[value]
+			}
+		}),
+		table.column({
 			accessor: 'years',
 			header: 'Age'
 		}),
@@ -30,15 +46,15 @@
 			header: 'Points de vie'
 		}),
 		table.column({
-			accessor: 'profession',
+			accessor: 'occupation',
 			header: 'Profession',
 			cell: ({ value }) => {
 				if (!value) {
 					return ''
 				}
 				return {
-					[ProfessionType.FARMER]: 'Fermier',
-					[ProfessionType.CARPENTER]: 'Charpentier'
+					[OccupationType.FARMER]: 'Fermier',
+					[OccupationType.CARPENTER]: 'Charpentier'
 				}[value]
 			}
 		})

--- a/apps/front/src/routes/rules/+page.svelte
+++ b/apps/front/src/routes/rules/+page.svelte
@@ -43,12 +43,11 @@
 					Le monde reconstitue ses réserves de ressources suivant ces règles
 					<ol class="list-inside list-decimal">
 						<li>
-							au printemps<br /> 50 de nourriture avec un bonus de 20 par civilisations active
+							au printemps<br /> 50 de nourriture avec un bonus de 20 par civilisation active
 						</li>
-						<li>en été<br /> 25 de nourriture avec un bonus de 10 par civilisations active</li>
+						<li>en été<br /> 25 de nourriture avec un bonus de 10 par civilisation active</li>
 						<li>
-							en automne<br /> 10 de nourriture avec un bonus de 5 par civilisations active et 10 de
-							bois
+							en automne<br /> 10 de nourriture avec un bonus de 5 par civilisation active et 10 de bois
 						</li>
 						<li>en hiver<br />20 de bois</li>
 					</ol>

--- a/apps/front/src/types/citizen.ts
+++ b/apps/front/src/types/citizen.ts
@@ -1,7 +1,14 @@
-import type { ProfessionType } from './profession'
+import type { OccupationType } from './occupation'
+
+export enum Gender {
+  FEMALE = 'female',
+  MALE = 'male',
+  UNKNOWN = 'unknown'
+}
 
 export type Citizen = {
-  profession: ProfessionType | undefined
+  occupation: OccupationType | undefined
+  gender: Gender
   years: number
   name: string
   month: number

--- a/apps/front/src/types/occupation.ts
+++ b/apps/front/src/types/occupation.ts
@@ -1,4 +1,4 @@
-export enum ProfessionType {
+export enum OccupationType {
   FARMER = 'farmer',
   CARPENTER = 'carpenter'
 }

--- a/apps/front/src/types/resource.ts
+++ b/apps/front/src/types/resource.ts
@@ -2,3 +2,4 @@ export enum ResourceType {
   WOOD = 'wood',
   FOOD = 'food'
 }
+


### PR DESCRIPTION
* /!\ `fontUrl` becomes `frontUrl` in backend env file
* /!\ `APP_PORT` env variable.
* .env example.
* rename 'profession' to 'occupation' -> Will possibly break existing civilizations despite the use of old profession attribtues as a backup in the civilization builder