### PR TITLE
feat(docker): launch the API backend from the back stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,9 @@ COPY --from=build-front /home/bun/app/apps/front/build ./dist
 FROM base AS back
 WORKDIR /home/bun/app/apps/back
 COPY --from=build-back /home/bun/app/apps/back/dist ./dist
+
+ENV NODE_ENV=production
+ENV APP_PORT=3000
+EXPOSE 3000
+
+CMD ["bun", "dist/index.js"]


### PR DESCRIPTION
## Contexte

Sur la branche `feat/style-rework`, le `back` stage du `Dockerfile` se contente de copier le `dist` issu du build mais ne démarre jamais l'API : aucun `CMD`/`ENTRYPOINT`, aucun port exposé et `APP_PORT` n'est pas défini (l'API fait `app.listen(process.env.APP_PORT!)`).

## Changement

Ajout au `back` stage :
- `ENV NODE_ENV=production`
- `ENV APP_PORT=3000` (valeur par défaut, alignée sur `apps/back/.env.dist` et `docker-compose.yml`)
- `EXPOSE 3000`
- `CMD ["bun", "dist/index.js"]` pour lancer l'API Elysia

L'image construite depuis le stage `back` démarre désormais directement le serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011RiReyLcLJLje2c8iKDrKv)_