### PR TITLE
feat(notifications): prévenir les défenseurs d'une attaque imminente via push PWA

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,1 +1,6 @@
 DOCKER_BACK_EXTERNAL_PORT=3000
+# Web Push (VAPID) — notifications PWA d'attaque imminente
+# Generer une paire avec: bunx web-push generate-vapid-keys
+VAPID_SUBJECT=mailto:no-reply@civilizations.darthoit.eu
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=

--- a/apps/back/db/schema/usersModel.ts
+++ b/apps/back/db/schema/usersModel.ts
@@ -1,5 +1,19 @@
 import { Schema } from 'mongoose'
 
+// Web Push (VAPID) subscription as returned by the browser PushManager. Stored
+// per user so the backend can push attack notifications to every device the
+// player has enabled.
+const PushSubscriptionSchema = new Schema(
+  {
+    endpoint: { type: String, required: true },
+    keys: {
+      p256dh: { type: String, required: true },
+      auth: { type: String, required: true },
+    },
+  },
+  { _id: false },
+)
+
 export const UserSchema = new Schema({
   username: {
     type: String,
@@ -18,6 +32,11 @@ export const UserSchema = new Schema({
   civilizations: [{
     type: Schema.Types.ObjectId,
     ref: 'Civilization'
-  }]
+  }],
+  pushSubscriptions: {
+    type: [PushSubscriptionSchema],
+    required: true,
+    default: [],
+  }
 })
 

--- a/apps/back/package.json
+++ b/apps/back/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/through2": "^2.0.41",
+    "@types/web-push": "^3.6.4",
     "react-email": "5.0.4"
   },
   "peerDependencies": {
@@ -35,6 +36,7 @@
     "elysia-compress": "^1.2.1",
     "mongodb": "^7.0.0",
     "mongoose": "^8.20.0",
-    "through2": "^4.0.2"
+    "through2": "^4.0.2",
+    "web-push": "^3.6.7"
   }
 }

--- a/apps/back/src/index.ts
+++ b/apps/back/src/index.ts
@@ -11,6 +11,7 @@ import { jwtMiddleware } from "./libs/jwt";
 import { authModule } from "./modules/auth";
 import { civilizationModule } from "./modules/civilizations";
 import { peopleModule } from "./modules/people";
+import { pushModule } from "./modules/push";
 import { tradeOffersModule } from "./modules/trade-offers";
 import { usersModule } from "./modules/users";
 import { worldModule } from "./modules/world";
@@ -32,6 +33,7 @@ const app = new Elysia()
   .use(usersModule)
   .use(civilizationModule)
   .use(peopleModule)
+  .use(pushModule)
   .use(tradeOffersModule);
 
 
@@ -42,3 +44,4 @@ console.log(`🦄 Server started at ${app.server?.url}`);
 export type App = typeof app;
 
 export type { UpdateCivilizationDtoType } from './modules/civilizations/dto';
+export type { PushSubscriptionDtoType } from './modules/push';

--- a/apps/back/src/libs/services/pushSender.ts
+++ b/apps/back/src/libs/services/pushSender.ts
@@ -1,0 +1,106 @@
+import webpush from 'web-push'
+import { UserModel } from '../database/models'
+
+export type PushPayload = {
+  title: string
+  body: string
+  url?: string
+}
+
+const VAPID_SUBJECT = Bun.env.VAPID_SUBJECT ?? ''
+const VAPID_PUBLIC_KEY = Bun.env.VAPID_PUBLIC_KEY ?? ''
+const VAPID_PRIVATE_KEY = Bun.env.VAPID_PRIVATE_KEY ?? ''
+
+/**
+ * Sends Web Push (VAPID) notifications to users. Subscriptions are stored on the
+ * user document (`pushSubscriptions`). When the VAPID keys are missing the
+ * sender becomes a no-op so the app keeps working locally without push configured.
+ */
+export class PushSender {
+  private readonly enabled: boolean
+
+  constructor() {
+    this.enabled = Boolean(
+      VAPID_SUBJECT && VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY,
+    )
+
+    if (this.enabled) {
+      webpush.setVapidDetails(
+        VAPID_SUBJECT,
+        VAPID_PUBLIC_KEY,
+        VAPID_PRIVATE_KEY,
+      )
+    } else {
+      console.warn(
+        '[PushSender] VAPID keys missing, push notifications are disabled.',
+      )
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled
+  }
+
+  getPublicKey(): string {
+    return VAPID_PUBLIC_KEY
+  }
+
+  /**
+   * Sends a notification to every device a user registered. Dead subscriptions
+   * (HTTP 404/410) are pruned from the user document. Errors are swallowed so a
+   * failing push never breaks the calling flow.
+   */
+  async sendToUser(userId: string, payload: PushPayload): Promise<void> {
+    if (!this.enabled) {
+      return
+    }
+
+    const user = await UserModel.findById(userId, {
+      pushSubscriptions: 1,
+    }).lean()
+
+    const subscriptions = user?.pushSubscriptions ?? []
+    if (!subscriptions.length) {
+      return
+    }
+
+    const serializedPayload = JSON.stringify(payload)
+    const expiredEndpoints: string[] = []
+
+    await Promise.all(
+      subscriptions.map(async (subscription) => {
+        if (!subscription.keys?.p256dh || !subscription.keys?.auth) {
+          return
+        }
+        try {
+          await webpush.sendNotification(
+            {
+              endpoint: subscription.endpoint,
+              keys: {
+                p256dh: subscription.keys.p256dh,
+                auth: subscription.keys.auth,
+              },
+            },
+            serializedPayload,
+          )
+        } catch (error) {
+          const statusCode = (error as { statusCode?: number })?.statusCode
+          if (statusCode === 404 || statusCode === 410) {
+            expiredEndpoints.push(subscription.endpoint)
+          } else {
+            console.error('[PushSender] Failed to send notification', error)
+          }
+        }
+      }),
+    )
+
+    if (expiredEndpoints.length) {
+      await UserModel.updateOne(
+        { _id: userId },
+        { $pull: { pushSubscriptions: { endpoint: { $in: expiredEndpoints } } } },
+      )
+    }
+  }
+}
+
+export const pushSender = new PushSender()

--- a/apps/back/src/modules/civilizations/service.ts
+++ b/apps/back/src/modules/civilizations/service.ts
@@ -25,6 +25,7 @@ import { PeopleService, personMapper } from '../people/service'
 import { UpdateCivilizationDtoType } from './dto'
 import { AnyBulkWriteOperation } from 'mongoose'
 import { arrayToMap } from '../../utils'
+import { pushSender } from '../../libs/services/pushSender'
 
 type MongoBuildingType = BuildingType & { buildingType: BuildingTypes }
 
@@ -599,6 +600,65 @@ export class CivilizationService {
             defaultCivilizationConfig.AT_WAR_WITH,
         },
       },
+    )
+
+    // Warn the owners of newly targeted civilizations that a war was just
+    // declared against them, so they can react (walls, military ratio) before
+    // the attack resolves on the next month. Best-effort: never fails the update.
+    if (body.atWarWith) {
+      const previousTargets = new Set(
+        (currentConfig.AT_WAR_WITH ?? []).map(String),
+      )
+      const newTargets = body.atWarWith.filter(
+        (targetId) => !previousTargets.has(String(targetId)),
+      )
+      if (newTargets.length) {
+        await this.notifyWarTargets(
+          civilizationToUpdate.name,
+          civilizationToUpdate.id,
+          newTargets,
+        ).catch((error) =>
+          console.error('[CivilizationService] Failed to notify war targets', error),
+        )
+      }
+    }
+  }
+
+  /**
+   * Sends a push notification to the owner of each newly attacked civilization.
+   * Skips civilizations owned by the attacker (e.g. attacking your own second
+   * civilization).
+   */
+  private async notifyWarTargets(
+    attackerName: string,
+    attackerCivId: string,
+    targetCivIds: string[],
+  ): Promise<void> {
+    await Promise.all(
+      targetCivIds.map(async (targetCivId) => {
+        const [targetCiv, owner] = await Promise.all([
+          CivilizationModel.findById(targetCivId, { name: 1 }).lean(),
+          UserModel.findOne(
+            { civilizations: targetCivId },
+            { _id: 1, civilizations: 1 },
+          ).lean(),
+        ])
+
+        if (!targetCiv || !owner) {
+          return
+        }
+
+        // Don't notify a player about attacking their own civilization.
+        if (owner.civilizations?.map(String).includes(String(attackerCivId))) {
+          return
+        }
+
+        await pushSender.sendToUser(String(owner._id), {
+          title: '⚔️ Attaque imminente !',
+          body: `${attackerName} a déclaré la guerre à ${targetCiv.name}. Préparez vos défenses !`,
+          url: `/my-civilizations/${targetCivId}`,
+        })
+      }),
     )
   }
 

--- a/apps/back/src/modules/push/index.ts
+++ b/apps/back/src/modules/push/index.ts
@@ -1,0 +1,54 @@
+import Elysia, { t } from 'elysia'
+import { logger } from '@bogeychan/elysia-logger'
+
+import { authorization } from '../../libs/handlers/authorization'
+import { jwtMiddleware } from '../../libs/jwt'
+import { pushSender } from '../../libs/services/pushSender'
+import { UserModel } from '../../libs/database/models'
+
+export const PushSubscriptionDto = t.Object({
+  endpoint: t.String(),
+  keys: t.Object({
+    p256dh: t.String(),
+    auth: t.String(),
+  }),
+})
+
+export type PushSubscriptionDtoType = typeof PushSubscriptionDto.static
+
+export const pushModule = new Elysia({ prefix: '/push' })
+  .use(logger())
+  .use(jwtMiddleware)
+  // Public: the front needs the VAPID public key to create a subscription.
+  .get('/public-key', () => ({ publicKey: pushSender.getPublicKey() }))
+  .use(authorization('You need to login to manage push notifications'))
+  // Named `register`/`unregister` rather than `subscribe` because the Eden
+  // treaty client reserves `.subscribe` for opening WebSocket connections.
+  .post(
+    '/register',
+    async ({ user, body }) => {
+      // Upsert by endpoint so re-subscribing the same device does not create
+      // duplicates.
+      await UserModel.updateOne(
+        { _id: user.id },
+        { $pull: { pushSubscriptions: { endpoint: body.endpoint } } },
+      )
+      await UserModel.updateOne(
+        { _id: user.id },
+        { $push: { pushSubscriptions: body } },
+      )
+      return { subscribed: true }
+    },
+    { body: PushSubscriptionDto },
+  )
+  .post(
+    '/unregister',
+    async ({ user, body }) => {
+      await UserModel.updateOne(
+        { _id: user.id },
+        { $pull: { pushSubscriptions: { endpoint: body.endpoint } } },
+      )
+      return { subscribed: false }
+    },
+    { body: t.Object({ endpoint: t.String() }) },
+  )

--- a/apps/front/src/lib/components/NotificationToggle.svelte
+++ b/apps/front/src/lib/components/NotificationToggle.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import { toast } from 'svelte-sonner'
+	import {
+		disablePush,
+		enablePush,
+		getPushState,
+		isPushSupported,
+		type PushState
+	} from '../../services/push'
+
+	interface Props {
+		authToken?: string
+	}
+
+	let { authToken }: Props = $props()
+
+	let pushState: PushState = $state('unsupported')
+	let loading = $state(false)
+
+	onMount(async () => {
+		if (!isPushSupported()) {
+			pushState = 'unsupported'
+			return
+		}
+		pushState = await getPushState()
+	})
+
+	const toggle = async () => {
+		if (!authToken) {
+			toast.error('Vous devez être connecté pour activer les notifications.')
+			return
+		}
+		loading = true
+		try {
+			if (pushState === 'enabled') {
+				pushState = await disablePush(authToken)
+				toast.success("Notifications d'attaque désactivées")
+			} else {
+				pushState = await enablePush(authToken)
+				if (pushState === 'enabled') {
+					toast.success("Notifications d'attaque activées")
+				} else if (pushState === 'denied') {
+					toast.error(
+						'Les notifications sont bloquées dans votre navigateur. Autorisez-les pour être prévenu des attaques.'
+					)
+				}
+			}
+		} catch (error) {
+			console.error(error)
+			toast.error(
+				error instanceof Error
+					? error.message
+					: 'Impossible de modifier les notifications.'
+			)
+		} finally {
+			loading = false
+		}
+	}
+</script>
+
+<div class="civ-inner-card">
+	<h2 class="civ-section-title">Notifications d'attaque</h2>
+
+	{#if pushState === 'unsupported'}
+		<p style="font-size:15px; color:oklch(0.5 0.03 50); margin:0;">
+			Votre navigateur ne supporte pas les notifications push. Installez l'application
+			(PWA) ou utilisez un navigateur compatible pour être prévenu des attaques.
+		</p>
+	{:else}
+		<p style="font-size:15px; color:oklch(0.48 0.03 50); margin:0 0 14px;">
+			Recevez une notification dès qu'une civilisation vous déclare la guerre, pour avoir
+			le temps de préparer vos défenses.
+		</p>
+
+		{#if pushState === 'denied'}
+			<p style="font-size:14px; color:oklch(0.5 0.13 34); margin:0 0 14px;">
+				Les notifications sont actuellement bloquées dans les réglages de votre navigateur.
+			</p>
+		{/if}
+
+		<button
+			type="button"
+			onclick={toggle}
+			disabled={loading || pushState === 'denied'}
+			style="align-self:flex-start; padding:12px 22px; border:none; border-radius:4px; background:{pushState ===
+			'enabled'
+				? 'oklch(0.5 0.06 40)'
+				: 'oklch(0.5 0.13 34)'}; color:oklch(0.95 0.02 84); font-family:'Marcellus',serif; font-size:17px; cursor:{loading ||
+			pushState === 'denied'
+				? 'not-allowed'
+				: 'pointer'}; opacity:{loading || pushState === 'denied' ? 0.6 : 1}; box-shadow:0 4px 12px rgba(80,30,20,.24);"
+		>
+			{#if loading}
+				Patientez…
+			{:else if pushState === 'enabled'}
+				Désactiver les notifications
+			{:else}
+				Activer les notifications
+			{/if}
+		</button>
+	{/if}
+</div>

--- a/apps/front/src/prompt-sw.ts
+++ b/apps/front/src/prompt-sw.ts
@@ -13,6 +13,51 @@ self.addEventListener('message', (event) => {
   }
 })
 
+// Web Push: show the attack notification sent by the backend.
+self.addEventListener('push', (event) => {
+  if (!event.data) {
+    return
+  }
+
+  let payload: { title?: string; body?: string; url?: string } = {}
+  try {
+    payload = event.data.json()
+  } catch {
+    payload = { title: 'Civilisations', body: event.data.text() }
+  }
+
+  const title = payload.title ?? 'Civilisations'
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: payload.body ?? '',
+      icon: '/favicon.png',
+      badge: '/favicon.png',
+      data: { url: payload.url ?? '/' },
+    }),
+  )
+})
+
+// Focus an existing tab on the target url or open a new one when the user taps
+// the notification.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const targetUrl = (event.notification.data as { url?: string })?.url ?? '/'
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if ('focus' in client) {
+            client.navigate(targetUrl)
+            return client.focus()
+          }
+        }
+        return self.clients.openWindow(targetUrl)
+      }),
+  )
+})
+
 // self.__WB_MANIFEST is default injection point
 precacheAndRoute(self.__WB_MANIFEST)
 

--- a/apps/front/src/routes/me/+page.server.ts
+++ b/apps/front/src/routes/me/+page.server.ts
@@ -21,6 +21,7 @@ export const load: PageServerLoad = async ({ cookies, url }) => {
 
   return {
     user,
+    authToken: cookies.get('auth'),
     passwordChangeForm: await superValidate(zod(passwordChangeSchema))
   }
 }

--- a/apps/front/src/routes/me/+page.svelte
+++ b/apps/front/src/routes/me/+page.svelte
@@ -12,6 +12,7 @@
 		FormFieldErrors,
 		FormLabel
 	} from '$lib/components/ui/form'
+	import NotificationToggle from '$lib/components/NotificationToggle.svelte'
 
 	interface Props {
 		data: PageData;
@@ -52,6 +53,8 @@
 		{#if userStore.value}
 			<p style="font-size:18px; color:oklch(0.48 0.03 50); margin:0;">Bonjour, <strong style="color:oklch(0.38 0.06 40);">{userStore.value.username}</strong></p>
 		{/if}
+
+		<NotificationToggle authToken={data.authToken} />
 
 		<div class="civ-inner-card">
 			<h2 class="civ-section-title">Changer mon mot de passe</h2>

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
 	import type { PageData } from './$types'
-	import { Settings, ZoomIn } from '@lucide/svelte'
+	import { Settings, ZoomIn, Hammer } from '@lucide/svelte'
 	import {
 		Resource,
 		ResourceTypes,
 		type BuildingType,
+		BuildingTypes,
 		type OccupationTypes,
 		type PeopleType,
 		Events
 	} from '@ajustor/simulation'
 	import BuildingsTable from './datatables/buildings-table.svelte'
-	import { OCCUPATIONS, resourceNames, eventsName, eventsDescription } from '$lib/translations'
+	import { OCCUPATIONS, resourceNames, eventsName, eventsDescription, buildingNames } from '$lib/translations'
 	import PeopleTable from './datatables/people-table.svelte'
 	import { callGetPeople } from '../../../services/sveltekit-api/people'
 
@@ -61,6 +62,45 @@
 	]
 
 	const maxResourceQty = $derived(Math.max(...data.civilization.resources.map(r => r.quantity), 1))
+
+	// ── Constructions en cours ─────────────────────────────────────────────────
+	// Group pending constructions by building type, and within each type by the
+	// number of months remaining, so a player sees how many of each building are
+	// coming and when.
+	type PendingGroup = {
+		buildingType: BuildingTypes
+		count: number
+		breakdown: { monthsRemaining: number; count: number }[]
+	}
+	const pendingConstructions = $derived<{ buildingType: BuildingTypes; monthsRemaining: number }[]>(
+		data.civilization.pendingConstructions ?? []
+	)
+	const pendingGroups = $derived<PendingGroup[]>(
+		Object.values(
+			pendingConstructions.reduce<Record<string, PendingGroup>>((acc, { buildingType, monthsRemaining }) => {
+				const group = (acc[buildingType] ??= { buildingType, count: 0, breakdown: [] })
+				group.count++
+				const slot = group.breakdown.find((b) => b.monthsRemaining === monthsRemaining)
+				if (slot) {
+					slot.count++
+				} else {
+					group.breakdown.push({ monthsRemaining, count: 1 })
+				}
+				return acc
+			}, {})
+		)
+			.map((group) => ({
+				...group,
+				breakdown: group.breakdown.sort((a, b) => a.monthsRemaining - b.monthsRemaining)
+			}))
+			.sort((a, b) => b.count - a.count)
+	)
+	const monthsLabel = (monthsRemaining: number) =>
+		monthsRemaining <= 0
+			? 'Bientôt prête'
+			: monthsRemaining === 1
+				? 'Prête le mois prochain'
+				: `Prête dans ${monthsRemaining} mois`
 
 	// ── Stat helpers ──────────────────────────────────────────────────────────
 	const fmt = (n: number) => Math.round(n).toLocaleString('fr-FR')
@@ -557,6 +597,38 @@
 		<div class="civ-inner-card" style="margin-top:20px;">
 			<h2 class="civ-section-title">Bâtiments ({data.civilization.buildings.reduce((a, { count }) => a + count, 0)} au total)</h2>
 			<BuildingsTable buildings={data.civilization.buildings} />
+		</div>
+
+		<!-- Constructions en cours -->
+		<div class="civ-inner-card" style="margin-top:20px;">
+			<div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
+				<Hammer size="18" style="color:oklch(0.5 0.1 50); flex-shrink:0;" />
+				<h2 class="civ-section-title" style="margin:0;">Constructions en cours ({pendingConstructions.length} au total)</h2>
+			</div>
+
+			{#if pendingGroups.length === 0}
+				<p style="color:oklch(0.55 0.03 50); font-size:15px; font-style:italic; margin-top:8px;">Aucune construction en cours pour le moment.</p>
+			{:else}
+				<div style="display:flex; flex-direction:column; gap:10px; margin-top:12px;">
+					{#each pendingGroups as group (group.buildingType)}
+						<div style="display:flex; align-items:center; gap:12px; padding:12px 16px; border-radius:4px; background:oklch(0.97 0.01 84); border:1px solid oklch(0.83 0.04 70);">
+							<div style="flex:1; min-width:0;">
+								<div style="font-family:'Marcellus',serif; font-size:16px; color:oklch(0.35 0.04 40);">
+									{buildingNames[group.buildingType] ?? group.buildingType}
+									{#if group.count > 1}<span style="color:oklch(0.5 0.03 50); font-size:14px;"> ×{group.count}</span>{/if}
+								</div>
+								<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:6px;">
+									{#each group.breakdown as slot}
+										<span style="font-size:13px; color:oklch(0.42 0.06 50); background:oklch(0.92 0.03 78); border:1px solid oklch(0.82 0.04 70); border-radius:999px; padding:2px 10px;">
+											{#if group.breakdown.length > 1 || slot.count > 1}{slot.count} · {/if}{monthsLabel(slot.monthsRemaining)}
+										</span>
+									{/each}
+								</div>
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
 		</div>
 
 		<!-- Combat Log Summary -->

--- a/apps/front/src/services/api/push-api.ts
+++ b/apps/front/src/services/api/push-api.ts
@@ -1,0 +1,45 @@
+import { client } from './client'
+import type { PushSubscriptionDtoType } from '@ajustor/civ-api'
+
+export const getVapidPublicKey = async (): Promise<string> => {
+	const { data, error } = await client.push['public-key'].get()
+
+	if (error) {
+		console.error(error)
+		throw error
+	}
+
+	return data.publicKey
+}
+
+export const subscribeToPush = async (
+	authToken: string,
+	subscription: PushSubscriptionDtoType
+) => {
+	const { error } = await client.push.register.post(subscription, {
+		headers: {
+			authorization: `Bearer ${authToken}`
+		}
+	})
+
+	if (error) {
+		console.error(error)
+		throw error
+	}
+}
+
+export const unsubscribeFromPush = async (authToken: string, endpoint: string) => {
+	const { error } = await client.push.unregister.post(
+		{ endpoint },
+		{
+			headers: {
+				authorization: `Bearer ${authToken}`
+			}
+		}
+	)
+
+	if (error) {
+		console.error(error)
+		throw error
+	}
+}

--- a/apps/front/src/services/push.ts
+++ b/apps/front/src/services/push.ts
@@ -1,0 +1,88 @@
+import { getVapidPublicKey, subscribeToPush, unsubscribeFromPush } from './api/push-api'
+
+export type PushState = 'unsupported' | 'denied' | 'enabled' | 'disabled'
+
+export const isPushSupported = (): boolean =>
+	typeof window !== 'undefined' &&
+	'serviceWorker' in navigator &&
+	'PushManager' in window &&
+	'Notification' in window
+
+/** Converts a base64url VAPID public key into the Uint8Array the API expects. */
+const urlBase64ToUint8Array = (base64String: string): Uint8Array => {
+	const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+	const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+	const rawData = atob(base64)
+	const outputArray = new Uint8Array(rawData.length)
+	for (let i = 0; i < rawData.length; i++) {
+		outputArray[i] = rawData.charCodeAt(i)
+	}
+	return outputArray
+}
+
+const getRegistration = async (): Promise<ServiceWorkerRegistration> =>
+	(await navigator.serviceWorker.getRegistration()) ??
+	(await navigator.serviceWorker.ready)
+
+export const getPushState = async (): Promise<PushState> => {
+	if (!isPushSupported()) {
+		return 'unsupported'
+	}
+	if (Notification.permission === 'denied') {
+		return 'denied'
+	}
+
+	const registration = await navigator.serviceWorker.getRegistration()
+	const subscription = await registration?.pushManager.getSubscription()
+	return subscription ? 'enabled' : 'disabled'
+}
+
+/**
+ * Requests notification permission, subscribes the device through the
+ * PushManager and registers the subscription on the backend.
+ */
+export const enablePush = async (authToken: string): Promise<PushState> => {
+	if (!isPushSupported()) {
+		return 'unsupported'
+	}
+
+	const permission = await Notification.requestPermission()
+	if (permission !== 'granted') {
+		return permission === 'denied' ? 'denied' : 'disabled'
+	}
+
+	const registration = await getRegistration()
+	const publicKey = await getVapidPublicKey()
+	if (!publicKey) {
+		throw new Error('Les notifications push ne sont pas configurées sur le serveur.')
+	}
+
+	const subscription =
+		(await registration.pushManager.getSubscription()) ??
+		(await registration.pushManager.subscribe({
+			userVisibleOnly: true,
+			applicationServerKey: urlBase64ToUint8Array(publicKey) as BufferSource
+		}))
+
+	await subscribeToPush(authToken, subscription.toJSON() as never)
+	return 'enabled'
+}
+
+/** Removes the browser subscription and unregisters it on the backend. */
+export const disablePush = async (authToken: string): Promise<PushState> => {
+	if (!isPushSupported()) {
+		return 'unsupported'
+	}
+
+	const registration = await navigator.serviceWorker.getRegistration()
+	const subscription = await registration?.pushManager.getSubscription()
+
+	if (subscription) {
+		await unsubscribeFromPush(authToken, subscription.endpoint).catch((error) =>
+			console.error(error)
+		)
+		await subscription.unsubscribe()
+	}
+
+	return 'disabled'
+}

--- a/bun.lock
+++ b/bun.lock
@@ -47,10 +47,12 @@
         "mongodb": "^7.0.0",
         "mongoose": "^8.20.0",
         "through2": "^4.0.2",
+        "web-push": "^3.6.7",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/through2": "^2.0.41",
+        "@types/web-push": "^3.6.4",
         "react-email": "5.0.4",
       },
       "peerDependencies": {
@@ -1022,6 +1024,8 @@
 
     "@types/validator": ["@types/validator@13.15.10", "", {}, "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA=="],
 
+    "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
+
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
@@ -1160,6 +1164,8 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
+    "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
+
     "async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
@@ -1214,6 +1220,8 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
+    "bn.js": ["bn.js@4.12.4", "", {}, "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1227,6 +1235,8 @@
     "bson": ["bson@7.0.0", "", {}, "sha512-Kwc6Wh4lQ5OmkqqKhYGKIuELXl+EPYSCObVE6bWsp1T/cGkOCBN0I8wF/T44BiuhHyNi1mmKVPXk60d41xZ7kw=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -1401,6 +1411,8 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
@@ -1650,6 +1662,8 @@
 
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
+    "http_ece": ["http_ece@1.2.0", "", {}, "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="],
+
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
@@ -1863,6 +1877,10 @@
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "kareem": ["kareem@2.6.3", "", {}, "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="],
 
@@ -2573,6 +2591,8 @@
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "weapon-regex": ["weapon-regex@1.3.6", "", {}, "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA=="],
+
+    "web-push": ["web-push@3.6.7", "", { "dependencies": { "asn1.js": "^5.3.0", "http_ece": "1.2.0", "https-proxy-agent": "^7.0.0", "jws": "^4.0.0", "minimist": "^1.2.5" }, "bin": { "web-push": "src/cli.js" } }, "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 


### PR DESCRIPTION
## Contexte

Aujourd'hui, une civilisation déclare la guerre en ajoutant une cible à `AT_WAR_WITH` (config), et l'attaque se résout au prochain passage de mois (cron `passAMonth` → `world.resolveWars`). Le joueur défenseur n'apprenait l'attaque **qu'après coup** via les combat-logs — résultat : peu d'interventions (murs, ratio militaire) car personne n'est prévenu à temps.

Cette PR ajoute des **notifications push PWA (Web Push / VAPID)** qui préviennent le joueur défenseur **dès la déclaration de guerre**, pour lui laisser le temps de réagir avant la résolution du combat — et ainsi augmenter les interventions des joueurs.

## Comportement

- Quand un joueur ajoute une civ adverse dans « Civilisations à attaquer » (config), le **propriétaire de la civ ciblée** reçoit une notification :
  > ⚔️ Attaque imminente ! — `<Attaquant>` a déclaré la guerre à `<Cible>`. Préparez vos défenses !
- Un clic sur la notification ouvre la page de la civilisation visée.
- L'utilisateur active/désactive les notifications depuis la page **Mon compte** (`/me`).

## Changements

**Backend (`apps/back`)**
- `web-push` ajouté ; abonnements push stockés par utilisateur (`User.pushSubscriptions`).
- `PushSender` (VAPID) — no-op si les clés ne sont pas configurées ; nettoie les abonnements expirés (404/410).
- Module `/push` : `GET /public-key`, `POST /register`, `POST /unregister` (routes nommées `register`/`unregister` car Eden réserve `.subscribe` pour le WebSocket).
- `civilizationService.update` : diff de `atWarWith`, notifie le propriétaire de chaque nouvelle cible (best-effort, n'échoue jamais la sauvegarde ; ne se notifie pas soi-même).

**Frontend (`apps/front`)**
- Service worker : handlers `push` + `notificationclick`.
- Client API push + helper navigateur (permission, souscription PushManager, conversion clé VAPID).
- Composant `NotificationToggle.svelte` intégré à `/me`.

## Configuration requise

Générer une paire VAPID et renseigner les variables d'env du backend :

```bash
bunx web-push generate-vapid-keys
```

```
VAPID_SUBJECT=mailto:no-reply@civilizations.darthoit.eu
VAPID_PUBLIC_KEY=...
VAPID_PRIVATE_KEY=...
```

Sans ces clés, l'envoi est désactivé proprement (no-op) et le reste de l'app fonctionne normalement.

## Vérification

- `apps/back` : `bun run build` OK, `tsc --noEmit` sans erreur sur les fichiers touchés.
- `apps/front` : `bun run check` — aucune nouvelle erreur introduite (les erreurs restantes sont préexistantes, liées au mismatch zod/superValidate déjà présent sur login/register).
- Test manuel : activer les notifications sur `/me` (permission accordée → `POST /push/register`), puis depuis un 2e compte déclarer la guerre à la civ du 1er → le 1er reçoit la notification ; clic → ouvre la page de la civ. Désactiver le toggle → `POST /push/unregister`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XMmLmNNSV7UNzC9RPgfBq)_