### PR TITLE
feat: noms des citoyens, refresh live SSE, fil d'Ariane, police manus…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM oven/bun:slim AS base
 WORKDIR /home/bun/app
 
 ENV NX_DAEMON=false
+# NX 22 isolates plugins in worker processes that fail to spawn in this restricted
+# build environment ("Failed to start plugin worker"). Run plugins in-process instead.
+ENV NX_ISOLATE_PLUGINS=false
 
 COPY . .
 

--- a/apps/back/backfillNames.ts
+++ b/apps/back/backfillNames.ts
@@ -1,0 +1,84 @@
+import mongoose from 'mongoose'
+import { names, uniqueNamesGenerator } from 'unique-names-generator'
+import { PersonModel } from './src/libs/database/models'
+
+const generateName = () => uniqueNamesGenerator({ dictionaries: [names] })
+
+/**
+ * One-off migration: assigns a stable name to every citizen created before the
+ * `name` field existed. Run manually after deploying with:
+ *   bun run backfillNames.ts
+ * It is idempotent — already-named citizens are left untouched, so it is safe to
+ * run more than once.
+ */
+async function backfillNames(): Promise<void> {
+  const missingNameFilter = {
+    $or: [{ name: { $exists: false } }, { name: null }, { name: '' }],
+  }
+
+  const total = await PersonModel.countDocuments(missingNameFilter)
+  console.log(`${total} citizens without a name to backfill`)
+
+  let processed = 0
+  const BATCH_SIZE = 1000
+  const cursor = PersonModel.find(missingNameFilter, '_id child')
+    .batchSize(BATCH_SIZE)
+    .cursor()
+
+  let operations: Parameters<typeof PersonModel.bulkWrite>[0] = []
+
+  const flush = async () => {
+    if (!operations.length) {
+      return
+    }
+    await PersonModel.bulkWrite(operations)
+    processed += operations.length
+    console.log(`  …${processed}/${total} updated`)
+    operations = []
+  }
+
+  for await (const person of cursor) {
+    const update: { name: string; 'child.name'?: string } = {
+      name: generateName(),
+    }
+
+    // The unborn child is an embedded sub-document; give it a name too when it
+    // exists and does not have one yet.
+    const child = (person as unknown as { child?: { name?: string } | null }).child
+    if (child && !child.name) {
+      update['child.name'] = generateName()
+    }
+
+    operations.push({
+      updateOne: {
+        filter: { _id: person._id },
+        update: { $set: update },
+      },
+    })
+
+    if (operations.length >= BATCH_SIZE) {
+      await flush()
+    }
+  }
+
+  await flush()
+
+  console.log(`Done. ${processed} citizens backfilled.`)
+}
+
+try {
+  mongoose.connection.on(
+    'error',
+    console.error.bind(console, 'MongoDB connection error:'),
+  )
+  await mongoose.connect(Bun.env.mongoConnectString ?? '')
+
+  console.log('MongoDB Connected')
+
+  await backfillNames()
+
+  process.exit(0)
+} catch (e) {
+  console.error(e instanceof Error ? e.message : e)
+  process.exit(1)
+}

--- a/apps/back/createANewWorld.ts
+++ b/apps/back/createANewWorld.ts
@@ -1,28 +1,25 @@
-import { EmailSender } from './src/libs/services/emailSender'
-import { ResourceTypes } from '@ajustor/simulation'
-import { WorldDestructionEmailTemplate } from './src/emailTemplates/worldDestruction'
-import {
-  CivilizationModel,
-  PersonModel,
-  UserModel,
-  WorldModel,
-} from './src/libs/database/models'
-import mongoose from 'mongoose'
+import mongoose from "mongoose";
+
+import { ResourceTypes } from "@ajustor/simulation";
+
+import { WorldDestructionEmailTemplate } from "./src/emailTemplates/worldDestruction";
+import { CivilizationModel, PersonModel, UserModel, WorldModel } from "./src/libs/database/models";
+import { EmailSender } from "./src/libs/services/emailSender";
 
 mongoose.connection.on(
   'error',
   console.error.bind(console, 'MongoDB connection error:'),
-)
-await mongoose.connect(Bun.env.mongoConnectString ?? '')
+);
+await mongoose.connect(Bun.env.mongoConnectString ?? '');
 
 const topCivilizations = await CivilizationModel.find().sort({
   livedMonths: 'desc',
-})
+});
 
-await PersonModel.deleteMany()
-await CivilizationModel.deleteMany()
+await PersonModel.deleteMany();
+await CivilizationModel.deleteMany();
 
-await WorldModel.deleteMany()
+await WorldModel.deleteMany();
 await WorldModel.create({
   name: 'The Holy kingdom',
   month: 0,
@@ -40,13 +37,13 @@ await WorldModel.create({
       quantity: 5000,
     },
   ],
-})
+});
 
-console.log(`Seeding complete.`)
-console.log('Sending emails')
-const emailService = new EmailSender()
-const users = await UserModel.find()
-const emails = users.map(({ email }) => email)
+console.log(`Seeding complete.`);
+console.log('Sending emails');
+const emailService = new EmailSender();
+const users = await UserModel.find();
+const emails = users.map(({ email }) => email);
 
 await emailService.sendBatch(
   emails,
@@ -54,4 +51,4 @@ await emailService.sendBatch(
   WorldDestructionEmailTemplate({
     topCivilizationsNames: topCivilizations.map(({ name }) => name),
   }),
-)
+).catch((error) => console.error(error));

--- a/apps/back/db/schema/personModel.ts
+++ b/apps/back/db/schema/personModel.ts
@@ -2,6 +2,7 @@ import { Gender, OccupationTypes, PeopleEntity } from '@ajustor/simulation'
 import { Schema } from 'mongoose'
 
 const PersonSchema = new Schema<PeopleEntity>({
+  name: String,
   gender: {
     type: String,
     enum: Gender

--- a/apps/back/db/schema/worldModel.ts
+++ b/apps/back/db/schema/worldModel.ts
@@ -23,6 +23,16 @@ export const worldSchema = new Schema({
     required: true,
     default: []
   },
+  // Per-world simulation config. Defaults mirror the simulation's defaultConfig so
+  // existing worlds keep their behaviour; set custom values to tune a single world.
+  config: {
+    type: new Schema({
+      BASE_FOOD_GENERATION: { type: Number, default: 30000 },
+      BASE_WOOD_GENERATION: { type: Number, default: 15000 },
+      EVENT_CHANCE: { type: Number, default: 30 },
+    }, { _id: false }),
+    default: () => ({})
+  },
   civilizations: [{
     type: Schema.Types.ObjectId,
     ref: 'Civilization'

--- a/apps/back/package.json
+++ b/apps/back/package.json
@@ -15,6 +15,7 @@
     "generate:migrations": "bunx drizzle-kit generate",
     "migration": "bun run migrations.ts",
     "populate": "bun run seed.ts",
+    "backfill:names": "bun run backfillNames.ts",
     "email:preview": "email dev --dir ./src",
     "passAMonth": "bun run src/cron/passAMonth.ts"
   },

--- a/apps/back/src/libs/handlers/authorization.ts
+++ b/apps/back/src/libs/handlers/authorization.ts
@@ -8,7 +8,10 @@ export const authorization = (message: string) => {
     .use(jwtMiddleware)
     .use(bearer())
     .derive(async ({ jwt, cookie: { auth }, set, bearer }) => {
-      const user = (await jwt.verify(auth.value ?? bearer) as User)
+      // Prefer the explicit bearer token sent by the API clients over the cookie:
+      // a stale/empty `auth` cookie on the API domain (e.g. cross-origin browser
+      // calls with credentials) must not shadow a valid Authorization header.
+      const user = (await jwt.verify(bearer || auth.value) as User)
 
       if (!user) {
         set.status = 403

--- a/apps/back/src/libs/handlers/authorization.ts
+++ b/apps/back/src/libs/handlers/authorization.ts
@@ -11,13 +11,14 @@ export const authorization = (message: string) => {
       // Prefer the explicit bearer token sent by the API clients over the cookie:
       // a stale/empty `auth` cookie on the API domain (e.g. cross-origin browser
       // calls with credentials) must not shadow a valid Authorization header.
-      const user = (await jwt.verify(bearer || auth.value) as User)
+      const token = bearer ?? (typeof auth.value === 'string' ? auth.value : undefined)
+      const user = (await jwt.verify(token) as User)
 
       if (!user) {
         set.status = 403
         throw new Error(message)
       }
       return { user }
-    }).as('plugin')
+    }).as('scoped')
   return plugin
 }

--- a/apps/back/src/libs/services/emailSender.ts
+++ b/apps/back/src/libs/services/emailSender.ts
@@ -51,4 +51,4 @@ export class EmailSender {
 
 export const emailSender = new Elysia({ name: 'EmailSender' }).derive(({ }) => {
   return { emailSender: new EmailSender() }
-}).as('plugin')
+}).as('scoped')

--- a/apps/back/src/libs/services/emailSender.ts
+++ b/apps/back/src/libs/services/emailSender.ts
@@ -7,20 +7,26 @@ export class EmailSender {
   private client = new Resend(Bun.env.RESEND_API_KEY)
 
   public async sendEmail(to: string, subject: string, template: ReactNode) {
-    const { data, error } = await this.client.emails.send({
-      from: 'My Civilizations <no-reply@civilizations.darthoit.eu>',
-      to,
-      subject,
-      react: template,
-    })
+    try {
+      const { data, error } = await this.client.emails.send({
+        from: 'My Civilizations <no-reply@civilizations.darthoit.eu>',
+        to,
+        subject,
+        react: template,
+      })
 
-    if (error) {
+      if (error) {
+        console.error(error)
+        return new Response(JSON.stringify({ error }))
+      }
 
-      console.error(error)
-      return new Response(JSON.stringify({ error }))
+      return new Response(JSON.stringify({ data }))
+    } catch (error) {
+      // Never let a transport/render failure throw to the caller: email is
+      // best-effort and must not break the action that triggered it.
+      console.error('sendEmail threw', error)
+      return new Response(JSON.stringify({ error: 'send failed' }))
     }
-
-    return new Response(JSON.stringify({ data }))
   }
 
   public async sendBatch(bcc: string[], subject: string, template: ReactNode) {

--- a/apps/back/src/libs/services/monthWatcher.ts
+++ b/apps/back/src/libs/services/monthWatcher.ts
@@ -1,0 +1,61 @@
+import { EventEmitter } from 'node:events'
+import { WorldModel } from '../database/models'
+
+/**
+ * Months are advanced every ~15 minutes by a separate process (`cron/passAMonth`),
+ * so the HTTP server cannot be notified in-process. Instead this singleton polls
+ * each world's `month` on a slow interval and emits an event when it changes, which
+ * the SSE endpoint (`GET /worlds/:worldId/events`) relays to connected browsers.
+ *
+ * Polling (rather than MongoDB change streams) keeps it working on a standalone
+ * Mongo instance with no replica set. At a 30s cadence against a 15-minute tick the
+ * cost is negligible and the on-screen refresh lands within half a minute.
+ */
+class MonthWatcher {
+  private readonly emitter = new EventEmitter()
+  private readonly months = new Map<string, number>()
+  private started = false
+  private timer: ReturnType<typeof setInterval> | null = null
+  private readonly POLL_MS = 30_000
+
+  private start() {
+    if (this.started) {
+      return
+    }
+    this.started = true
+    // No upper bound on concurrent SSE subscribers.
+    this.emitter.setMaxListeners(0)
+    void this.poll()
+    this.timer = setInterval(() => void this.poll(), this.POLL_MS)
+  }
+
+  private async poll() {
+    try {
+      const worlds = await WorldModel.find({}, 'month').lean()
+      for (const world of worlds) {
+        const worldId = String(world._id)
+        const month = (world as { month?: number }).month ?? 0
+        const previous = this.months.get(worldId)
+        this.months.set(worldId, month)
+        // Skip the first observation so subscribers are not refreshed on connect.
+        if (previous !== undefined && month !== previous) {
+          this.emitter.emit(worldId, month)
+        }
+      }
+    } catch (error) {
+      console.error('[MonthWatcher] poll failed', error)
+    }
+  }
+
+  /**
+   * Subscribes to month changes for a world. Starts the poller lazily on the first
+   * subscription. Returns an unsubscribe function.
+   */
+  onWorldMonthChange(worldId: string, listener: (month: number) => void): () => void {
+    this.start()
+    this.emitter.on(worldId, listener)
+    return () => this.emitter.off(worldId, listener)
+  }
+}
+
+export const monthWatcher = new MonthWatcher()

--- a/apps/back/src/modules/people/service.ts
+++ b/apps/back/src/modules/people/service.ts
@@ -3,7 +3,7 @@ import { MongoCivilizationType } from '../civilizations/service'
 import { CivilizationModel, PersonModel } from '../../libs/database/models'
 import { AnyBulkWriteOperation, SortOrder } from 'mongoose'
 
-export const personMapper = ({ id, gender, month, lifeCounter, occupation, buildingMonthsLeft, isBuilding, pregnancyMonthsLeft, child, lineage }: PeopleType): People => {
+export const personMapper = ({ id, name, gender, month, lifeCounter, occupation, buildingMonthsLeft, isBuilding, pregnancyMonthsLeft, child, lineage }: PeopleType): People => {
   const peopleBuilder = new PeopleBuilder()
     .withId(id)
     .withGender(gender)
@@ -11,6 +11,10 @@ export const personMapper = ({ id, gender, month, lifeCounter, occupation, build
     .withLifeCounter(lifeCounter)
     .withIsBuilding(isBuilding)
     .withBuildingMonthsLeft(buildingMonthsLeft)
+
+  if (name) {
+    peopleBuilder.withName(name)
+  }
 
   if (occupation) {
     peopleBuilder.withOccupation(occupation)

--- a/apps/back/src/modules/users/index.ts
+++ b/apps/back/src/modules/users/index.ts
@@ -17,13 +17,21 @@ export const usersModule = new Elysia({ prefix: '/users' })
   .post('', async ({ log, userDbClient, body, set, emailSender }) => {
     try {
       await userDbClient.create({ ...body, password: await Bun.password.hash(body.password) })
-      await emailSender.sendEmail(body.email, 'Un nouvel arrivant !', NewUserEmailTemplate({ username: body.username, frontUrl: Bun.env.frontUrl ?? '' }))
-      set.status = 201
     } catch (error) {
       log.error(error)
       set.status = 409
       throw new Error('An error occured while create your account', { cause: error?.message })
     }
+
+    // The welcome email is best-effort: a failure here must never roll back or
+    // block the account that was just created.
+    try {
+      await emailSender.sendEmail(body.email, 'Un nouvel arrivant !', NewUserEmailTemplate({ username: body.username, frontUrl: Bun.env.frontUrl ?? '' }))
+    } catch (error) {
+      log.error('Welcome email failed to send (account was still created)', error)
+    }
+
+    set.status = 201
   }
     , {
       body: t.Object({

--- a/apps/back/src/modules/world/database.ts
+++ b/apps/back/src/modules/world/database.ts
@@ -1,5 +1,19 @@
-import { World, WorldBuilder, Resource, ResourceTypes, Events } from '@ajustor/simulation'
+import { World, WorldBuilder, Resource, ResourceTypes, Events, type WorldConfig } from '@ajustor/simulation'
 import { WorldModel } from '../../libs/database/models'
+
+// Mongoose subdocuments don't spread reliably, so read each config field explicitly.
+// Returns undefined when no config is stored (older worlds) so the builder falls back
+// to the simulation defaults.
+const extractWorldConfig = (config?: Partial<WorldConfig> | null): Partial<WorldConfig> | undefined => {
+  if (!config) {
+    return undefined
+  }
+  return {
+    BASE_FOOD_GENERATION: config.BASE_FOOD_GENERATION,
+    BASE_WOOD_GENERATION: config.BASE_WOOD_GENERATION,
+    EVENT_CHANCE: config.EVENT_CHANCE,
+  }
+}
 
 export type GetOptions = {
   populate: {
@@ -20,7 +34,7 @@ export class WorldsTable {
     }
 
     const builder = new WorldBuilder()
-    builder.withName(world.name).withId(world.id).startingMonth(world.month)
+    builder.withName(world.name).withId(world.id).startingMonth(world.month).withConfig(extractWorldConfig(world.config))
 
     builder.addResource(...world.resources.map(({ quantity, resourceType }) => new Resource(resourceType as ResourceTypes, quantity ?? 0)))
 
@@ -35,7 +49,7 @@ export class WorldsTable {
 
     for (const world of worlds) {
       const builder = new WorldBuilder()
-      builder.withName(world.name).withId(world.id).startingMonth(world.month).withNextEvent(world.nextEvent as Events)
+      builder.withName(world.name).withId(world.id).startingMonth(world.month).withNextEvent(world.nextEvent as Events).withConfig(extractWorldConfig(world.config))
 
       builder.addResource(...world.resources.map(({ quantity, resourceType }) => new Resource(resourceType as ResourceTypes, quantity ?? 0)))
 
@@ -49,7 +63,7 @@ export class WorldsTable {
     for (const world of worlds) {
 
       console.time('worldSave')
-      await WorldModel.updateOne({ _id: world.id }, { month: world.getMonth(), nextEvent: world.nextEvent, resources: world.getResources().map(({ type, quantity }) => ({ resourceType: type, quantity })) })
+      await WorldModel.updateOne({ _id: world.id }, { month: world.getMonth(), nextEvent: world.nextEvent, config: world.getConfig(), resources: world.getResources().map(({ type, quantity }) => ({ resourceType: type, quantity })) })
       console.timeEnd('worldSave')
     }
   }

--- a/apps/back/src/modules/world/index.ts
+++ b/apps/back/src/modules/world/index.ts
@@ -5,6 +5,7 @@ import { WorldsTable } from './database'
 import { logger } from '@bogeychan/elysia-logger'
 import { WorldService } from './service'
 import { PeopleService } from '../people/service'
+import { monthWatcher } from '../../libs/services/monthWatcher'
 
 const worldDbClientInstance = new WorldsTable()
 const peopleServiceInstance = new PeopleService()
@@ -113,6 +114,44 @@ export const worldModule = new Elysia({ prefix: '/worlds' })
       withTopCivilizations: t.Optional(t.Boolean()),
       withMenAndWomenRatio: t.Optional(t.Boolean()),
     }))
+  })
+  // Server-Sent Events: pushes a `month` event whenever this world advances a
+  // month, so connected browsers can refresh on-screen data live. Public (only
+  // exposes a month number) so the browser's EventSource works without a bearer.
+  .get('/:worldId/events', ({ params: { worldId }, set }) => {
+    const encoder = new TextEncoder()
+    let unsubscribe: () => void = () => { }
+    let keepAlive: ReturnType<typeof setInterval>
+
+    const stream = new ReadableStream({
+      start(controller) {
+        const send = (chunk: string) => {
+          try {
+            controller.enqueue(encoder.encode(chunk))
+          } catch {
+            // Connection already closed; nothing to do.
+          }
+        }
+
+        send(`event: connected\ndata: {}\n\n`)
+
+        unsubscribe = monthWatcher.onWorldMonthChange(worldId, (month) => {
+          send(`event: month\ndata: ${JSON.stringify({ month })}\n\n`)
+        })
+
+        // Comment line keeps proxies from dropping the idle connection.
+        keepAlive = setInterval(() => send(`: keep-alive\n\n`), 25_000)
+      },
+      cancel() {
+        unsubscribe()
+        clearInterval(keepAlive)
+      },
+    })
+
+    set.headers['content-type'] = 'text/event-stream'
+    set.headers['cache-control'] = 'no-cache'
+    set.headers['connection'] = 'keep-alive'
+    return stream
   })
   .get('/:worldId/civilizations', async ({ civilizationsDbClient, params: { worldId } }) => {
     const civilizations = await civilizationsDbClient.getAllRawByWorldId(worldId, { people: false })

--- a/apps/front/src/app.html
+++ b/apps/front/src/app.html
@@ -6,7 +6,7 @@
 	<link rel="icon" href="%sveltekit.assets%/favicon.webp" as="image" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link href="https://fonts.googleapis.com/css2?family=Marcellus&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet" />
+	<link href="https://fonts.googleapis.com/css2?family=Marcellus&family=Tangerine:wght@400;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 	%sveltekit.head%
 </head>

--- a/apps/front/src/lib/components/Breadcrumb.svelte
+++ b/apps/front/src/lib/components/Breadcrumb.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	type Crumb = { label: string; href?: string }
+
+	let { items }: { items: Crumb[] } = $props()
+</script>
+
+<nav
+	aria-label="Fil d'Ariane"
+	style="font-family:'EB Garamond',serif; font-size:15px; color:oklch(0.55 0.03 50); margin-bottom:20px; animation:screenIn .4s ease both;"
+>
+	{#each items as item, i (i)}
+		{#if item.href && i < items.length - 1}
+			<a href={item.href} style="color:oklch(0.5 0.1 40); text-decoration:none;">{item.label}</a>
+		{:else}
+			<span aria-current="page" style="color:oklch(0.4 0.04 45);">{item.label}</span>
+		{/if}
+		{#if i < items.length - 1}
+			<span style="margin:0 6px; color:oklch(0.6 0.05 60);">›</span>
+		{/if}
+	{/each}
+</nav>

--- a/apps/front/src/routes/+page.svelte
+++ b/apps/front/src/routes/+page.svelte
@@ -50,7 +50,7 @@
 				<div style="display:flex; flex-wrap:wrap; justify-content:space-between; align-items:flex-start; gap:24px; border-bottom:2px solid oklch(0.72 0.05 60); padding-bottom:22px;">
 					<div>
 						<div style="font-family:'Marcellus',serif; font-size:13px; letter-spacing:.4em; text-transform:uppercase; color:oklch(0.5 0.09 40);">Chronique du monde</div>
-						<h1 style="font-family:'Marcellus',serif; font-size:clamp(40px,7vw,52px); margin:6px 0 0; color:oklch(0.3 0.04 40);">{world.name}</h1>
+						<h1 style="font-family:'Tangerine',cursive; font-size:clamp(40px,7vw,52px); margin:6px 0 0; color:oklch(0.3 0.04 40);">{world.name}</h1>
 						<div style="font-size:19px; color:oklch(0.46 0.03 50); margin-top:4px;">An {world.year} du monde</div>
 					</div>
 					<div style="width:104px; height:104px; border-radius:50%; background:radial-gradient(circle at 35% 30%, oklch(0.55 0.14 38), oklch(0.4 0.13 34)); color:oklch(0.94 0.03 84); display:flex; flex-direction:column; align-items:center; justify-content:center; box-shadow:0 6px 16px rgba(80,30,20,.35), inset 0 2px 6px rgba(255,220,180,.35); border:2px solid oklch(0.6 0.12 40); flex-shrink:0;">
@@ -79,13 +79,13 @@
 						<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:16px; margin-top:24px;">
 							{#await worldStats.aliveCivilizations then alive}
 								<div class="civ-inner-card">
-									<div style="font-family:'Marcellus',serif; font-size:40px; color:oklch(0.45 0.09 150);">{alive}</div>
+									<div style="font-family:'Tangerine',cursive; font-size:40px; color:oklch(0.45 0.09 150);">{alive}</div>
 									<div style="font-size:16px; color:oklch(0.48 0.03 50);">civilisations en vie</div>
 								</div>
 							{/await}
 							{#await worldStats.deadCivilizations then dead}
 								<div class="civ-inner-card">
-									<div style="font-family:'Marcellus',serif; font-size:40px; color:oklch(0.42 0.06 40);">{dead}</div>
+									<div style="font-family:'Tangerine',cursive; font-size:40px; color:oklch(0.42 0.06 40);">{dead}</div>
 									<div style="font-size:16px; color:oklch(0.48 0.03 50);">civilisations éteintes</div>
 								</div>
 							{/await}

--- a/apps/front/src/routes/login/+page.svelte
+++ b/apps/front/src/routes/login/+page.svelte
@@ -50,8 +50,8 @@
 	<div style="width:min(440px,100%); padding:clamp(28px,5vw,44px); border-radius:5px; background:radial-gradient(circle at 18% 12%, rgba(150,110,60,.07), transparent 45%), oklch(0.95 0.022 84); border:1px solid oklch(0.78 0.045 70); box-shadow:inset 0 0 0 6px oklch(0.93 0.03 84), inset 0 0 0 7px oklch(0.74 0.05 60), 0 22px 60px rgba(60,40,20,.22); animation:loginIn .5s cubic-bezier(.22,.72,.2,1) both;">
 		<!-- Logo + Brand -->
 		<div style="display:flex; flex-direction:column; align-items:center; text-align:center; margin-bottom:26px;">
-			<div style="width:72px; height:72px; border-radius:50%; background:radial-gradient(circle at 35% 30%, oklch(0.55 0.14 38), oklch(0.4 0.13 34)); color:oklch(0.94 0.03 84); display:flex; align-items:center; justify-content:center; font-family:'Marcellus',serif; font-size:34px; box-shadow:0 6px 16px rgba(80,30,20,.3), inset 0 2px 6px rgba(255,220,180,.4);">C</div>
-			<h1 style="font-family:'Marcellus',serif; font-size:38px; margin:18px 0 4px; color:oklch(0.3 0.04 40);">Civilizations</h1>
+			<div style="width:72px; height:72px; border-radius:50%; background:radial-gradient(circle at 35% 30%, oklch(0.55 0.14 38), oklch(0.4 0.13 34)); color:oklch(0.94 0.03 84); display:flex; align-items:center; justify-content:center; font-family:'Tangerine',cursive; font-size:34px; box-shadow:0 6px 16px rgba(80,30,20,.3), inset 0 2px 6px rgba(255,220,180,.4);">C</div>
+			<h1 style="font-family:'Tangerine',cursive; font-size:38px; margin:18px 0 4px; color:oklch(0.3 0.04 40);">Civilizations</h1>
 		</div>
 
 		<!-- Auth tabs -->

--- a/apps/front/src/routes/me/+page.svelte
+++ b/apps/front/src/routes/me/+page.svelte
@@ -13,6 +13,7 @@
 		FormLabel
 	} from '$lib/components/ui/form'
 	import NotificationToggle from '$lib/components/NotificationToggle.svelte'
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 
 	interface Props {
 		data: PageData;
@@ -48,8 +49,12 @@
 </svelte:head>
 
 <div class="civ-page-wrapper">
+	<Breadcrumb items={[
+		{ label: 'Mes civilisations', href: '/my-civilizations' },
+		{ label: 'Mon compte' }
+	]} />
 	<div class="civ-card" style="max-width:560px; margin:0 auto; display:flex; flex-direction:column; gap:20px; animation:screenIn .46s cubic-bezier(.22,.72,.2,1) .05s both;">
-		<h1 style="font-family:'Marcellus',serif; font-size:clamp(26px,4vw,36px); margin:0; color:oklch(0.3 0.04 40);">Mon compte</h1>
+		<h1 style="font-family:'Tangerine',cursive; font-size:clamp(26px,4vw,36px); margin:0; color:oklch(0.3 0.04 40);">Mon compte</h1>
 		{#if userStore.value}
 			<p style="font-size:18px; color:oklch(0.48 0.03 50); margin:0;">Bonjour, <strong style="color:oklch(0.38 0.06 40);">{userStore.value.username}</strong></p>
 		{/if}

--- a/apps/front/src/routes/my-civilizations/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/+page.svelte
@@ -44,6 +44,11 @@
 
 	const { form: formData, enhance } = form
 
+	// Pré-sélectionne le premier monde pour que la création cible toujours un monde.
+	if (worlds.length && !$formData.worldId) {
+		$formData.worldId = worlds[0].id
+	}
+
 	const openDeleteModal = (id: string) => {
 		civilizationIdToDelete = id
 		deleteDialogOpen = true
@@ -106,7 +111,7 @@
 					<FormDescription />
 					<FormFieldErrors />
 				</FormField>
-				{#if worlds.length > 1}
+				{#if worlds.length}
 					<FormField {form} name="worldId">
 						<FormControl>
 							{#snippet children({ props })}
@@ -125,8 +130,8 @@
 						</FormControl>
 						<FormFieldErrors />
 					</FormField>
-				{:else if worlds.length === 1}
-					<input type="hidden" name="worldId" value={worlds[0].id} />
+				{:else}
+					<p style="font-size:14px; color:oklch(0.5 0.03 50); margin:0;">Aucun monde disponible pour le moment.</p>
 				{/if}
 				<div style="display:flex; gap:10px; justify-content:flex-end;">
 					<button

--- a/apps/front/src/routes/my-civilizations/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/+page.svelte
@@ -178,7 +178,7 @@
 	<!-- Page header -->
 	<div style="display:flex; flex-wrap:wrap; justify-content:space-between; align-items:flex-end; gap:16px; margin-bottom:24px;" class="civ-animate-in">
 		<div>
-			<h1 style="font-family:'Marcellus',serif; font-size:clamp(32px,5vw,42px); margin:0; color:oklch(0.3 0.04 40);">Mes civilisations</h1>
+			<h1 style="font-family:'Tangerine',cursive; font-size:clamp(32px,5vw,42px); margin:0; color:oklch(0.3 0.04 40);">Mes civilisations</h1>
 			<div style="font-size:18px; color:oklch(0.48 0.03 50); margin-top:4px;">Vos lignées sous votre regard.</div>
 		</div>
 
@@ -220,11 +220,11 @@
 
 						<div style="display:flex; gap:24px; margin:16px 0;">
 							<div>
-								<div style="font-family:'Marcellus',serif; font-size:28px; color:oklch(0.45 0.09 150);">{civ.citizensCount}</div>
+								<div style="font-family:'Tangerine',cursive; font-size:28px; color:oklch(0.45 0.09 150);">{civ.citizensCount}</div>
 								<div style="font-size:14px; color:oklch(0.5 0.03 50);">citoyens</div>
 							</div>
 							<div>
-								<div style="font-family:'Marcellus',serif; font-size:28px; color:oklch(0.45 0.1 38);">{civ.buildings.reduce((a, b) => a + b.count, 0)}</div>
+								<div style="font-family:'Tangerine',cursive; font-size:28px; color:oklch(0.45 0.1 38);">{civ.buildings.reduce((a, b) => a + b.count, 0)}</div>
 								<div style="font-size:14px; color:oklch(0.5 0.03 50);">bâtiments</div>
 							</div>
 						</div>

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -13,7 +13,11 @@
 	import BuildingsTable from './datatables/buildings-table.svelte'
 	import { OCCUPATIONS, resourceNames, eventsName, eventsDescription, buildingNames } from '$lib/translations'
 	import PeopleTable from './datatables/people-table.svelte'
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 	import { callGetPeople } from '../../../services/sveltekit-api/people'
+	import { onMount } from 'svelte'
+	import { invalidateAll } from '$app/navigation'
+	import { PUBLIC_BACK_URL } from '$env/static/public'
 
 	interface Props {
 		data: PageData;
@@ -45,6 +49,23 @@
 			}
 		})
 	}
+
+	// Live refresh: the world advances a month every ~15 min server-side. Subscribe
+	// to its SSE stream and refresh the on-screen data whenever a month passes.
+	onMount(() => {
+		if (!data.worldId) {
+			return
+		}
+		const source = new EventSource(`${PUBLIC_BACK_URL}/worlds/${data.worldId}/events`)
+		source.addEventListener('month', async () => {
+			await invalidateAll()
+			// invalidateAll reloads page-0 citizens; refresh the page being viewed.
+			if (pageIndex !== 0) {
+				retrievePeople(pageIndex, pageSize)
+			}
+		})
+		return () => source.close()
+	})
 
 	const RESOURCES_INDEXES = {
 		[ResourceTypes.RAW_FOOD]: 0,
@@ -338,12 +359,12 @@
 									<div style="display:flex; flex-direction:column; gap:14px;">
 										<div>
 											<div style="font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:oklch(0.5 0.06 240); margin-bottom:4px;">Hommes</div>
-											<div style="font-size:28px; font-family:'Marcellus',serif; color:oklch(0.38 0.08 240);">{fmt(men)}</div>
+											<div style="font-size:28px; font-family:'Tangerine',cursive; color:oklch(0.38 0.08 240);">{fmt(men)}</div>
 											<div style="font-size:13px; color:oklch(0.5 0.04 50);">{pct(men, total)}% de la population</div>
 										</div>
 										<div style="border-top:1px solid oklch(0.82 0.03 72); padding-top:14px;">
 											<div style="font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:oklch(0.5 0.06 330); margin-bottom:4px;">Femmes</div>
-											<div style="font-size:28px; font-family:'Marcellus',serif; color:oklch(0.42 0.1 330);">{fmt(women)}</div>
+											<div style="font-size:28px; font-family:'Tangerine',cursive; color:oklch(0.42 0.1 330);">{fmt(women)}</div>
 											<div style="font-size:13px; color:oklch(0.5 0.04 50);">{pct(women, total)}% de la population</div>
 											<div style="font-size:13px; color:oklch(0.5 0.04 50); margin-top:4px;">dont enceintes : <strong style="color:oklch(0.38 0.08 130);">{fmt(pregnant)}</strong> ({pct(pregnant, women)}%)</div>
 										</div>
@@ -384,22 +405,25 @@
 
 <!-- ── Page ─────────────────────────────────────────────────────────────────── -->
 <div class="civ-page-wrapper">
-	<a href="/my-civilizations" style="background:none; border:none; cursor:pointer; font-family:'EB Garamond',serif; font-size:16px; color:oklch(0.5 0.06 40); padding:0; margin-bottom:14px; display:inline-block; text-decoration:none; animation:screenIn .4s ease both;">‹ Retour aux civilisations</a>
+	<Breadcrumb items={[
+		{ label: 'Mes civilisations', href: '/my-civilizations' },
+		{ label: data.civilization.name }
+	]} />
 
 	<div class="civ-card" style="animation:screenIn .46s cubic-bezier(.22,.72,.2,1) .05s both;">
 		<!-- Civ header -->
 		<div style="display:flex; flex-wrap:wrap; justify-content:space-between; align-items:flex-end; gap:20px; border-bottom:2px solid oklch(0.72 0.05 60); padding-bottom:20px;">
 			<div>
-				<h1 style="font-family:'Marcellus',serif; font-size:clamp(34px,6vw,46px); margin:0; color:oklch(0.3 0.04 40);">{data.civilization.name}</h1>
+				<h1 style="font-family:'Tangerine',cursive; font-size:clamp(34px,6vw,46px); margin:0; color:oklch(0.3 0.04 40);">{data.civilization.name}</h1>
 				<div style="font-size:18px; color:oklch(0.46 0.03 50); margin-top:4px;">Prospère depuis {~~(data.civilization.livedMonths / 12)} ans et {data.civilization.livedMonths % 12} mois</div>
 			</div>
 			<div style="display:flex; gap:26px; text-align:center; align-items:center;">
 				<div>
-					<div style="font-family:'Marcellus',serif; font-size:32px; color:oklch(0.42 0.09 150);">{data.civilization.citizensCount}</div>
+					<div style="font-family:'Tangerine',cursive; font-size:32px; color:oklch(0.42 0.09 150);">{data.civilization.citizensCount}</div>
 					<div style="font-size:14px; color:oklch(0.5 0.03 50);">citoyens</div>
 				</div>
 				<div>
-					<div style="font-family:'Marcellus',serif; font-size:32px; color:oklch(0.45 0.1 38);">{data.civilization.buildings.reduce((a, b) => a + b.count, 0)}</div>
+					<div style="font-family:'Tangerine',cursive; font-size:32px; color:oklch(0.45 0.1 38);">{data.civilization.buildings.reduce((a, b) => a + b.count, 0)}</div>
 					<div style="font-size:14px; color:oklch(0.5 0.03 50);">bâtiments</div>
 				</div>
 				{#if data.worldId}

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -84,7 +84,30 @@
 		'oklch(0.5 0.02 250)', 'oklch(0.55 0.11 45)'
 	]
 
-	const maxResourceQty = $derived(Math.max(...data.civilization.resources.map(r => r.quantity), 1))
+	// Storage capacity per resource = (number of Entrepôts) × the cache's per-resource
+	// max. Values mirror the Cache building in the simulation (buildings/cache.ts).
+	const STORAGE_PER_CACHE: Record<ResourceTypes, number> = {
+		[ResourceTypes.RAW_FOOD]: 300,
+		[ResourceTypes.COOKED_FOOD]: 100,
+		[ResourceTypes.WOOD]: 150,
+		[ResourceTypes.STONE]: 300,
+		[ResourceTypes.PLANK]: 150,
+		[ResourceTypes.CHARCOAL]: 150
+	}
+	const RESOURCE_COLORS: Record<ResourceTypes, string> = {
+		[ResourceTypes.RAW_FOOD]: 'oklch(0.58 0.13 135)',
+		[ResourceTypes.COOKED_FOOD]: 'oklch(0.62 0.13 60)',
+		[ResourceTypes.WOOD]: 'oklch(0.5 0.08 55)',
+		[ResourceTypes.STONE]: 'oklch(0.55 0.02 250)',
+		[ResourceTypes.PLANK]: 'oklch(0.62 0.07 85)',
+		[ResourceTypes.CHARCOAL]: 'oklch(0.42 0.02 250)'
+	}
+	const OVERFLOW_COLOR = 'oklch(0.55 0.2 28)'
+	const cacheCount = $derived(
+		data.civilization.buildings
+			.filter((b) => b.type === BuildingTypes.CACHE)
+			.reduce((sum, b) => sum + b.count, 0)
+	)
 
 	// ── Constructions en cours ─────────────────────────────────────────────────
 	// Group pending constructions by building type, and within each type by the
@@ -588,14 +611,30 @@
 			<h2 class="civ-section-title">Ressources actuelles</h2>
 			<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:12px 32px;">
 				{#each data.civilization.resources as resource}
+					{@const capacity = cacheCount * (STORAGE_PER_CACHE[resource.type] ?? 0)}
+					{@const over = Math.max(0, resource.quantity - capacity)}
+					{@const total = Math.max(resource.quantity, capacity, 1)}
+					{@const storedW = (Math.min(resource.quantity, capacity) / total) * 100}
+					{@const overW = (over / total) * 100}
 					<div>
-						<div style="display:flex; justify-content:space-between; font-size:16px; margin-bottom:4px;">
+						<div style="display:flex; justify-content:space-between; align-items:baseline; font-size:16px; margin-bottom:4px;">
 							<span>{resourceNames[resource.type]}</span>
-							<span style="color:oklch(0.5 0.03 50);">{resource.quantity}</span>
+							<span style="font-size:14px;">
+								<span style="color:{over > 0 ? OVERFLOW_COLOR : 'oklch(0.4 0.04 40)'}; font-weight:600;">{resource.quantity.toLocaleString('fr-FR')}</span>
+								<span style="color:oklch(0.55 0.03 50);"> / {capacity.toLocaleString('fr-FR')}</span>
+							</span>
 						</div>
-						<div class="civ-progress-bar">
-							<div class="civ-progress-fill" style="width:{Math.round((resource.quantity / maxResourceQty) * 100)}%; background:oklch(0.55 0.1 130);"></div>
+						<div class="civ-progress-bar" style="display:flex; overflow:hidden;">
+							<div style="width:{storedW}%; height:100%; background:{RESOURCE_COLORS[resource.type] ?? 'oklch(0.55 0.1 130)'}; transition:width .3s;"></div>
+							{#if overW > 0}
+								<div style="width:{overW}%; height:100%; background:{OVERFLOW_COLOR}; transition:width .3s;" title="Surplus au-delà de la capacité"></div>
+							{/if}
 						</div>
+						{#if capacity === 0}
+							<div style="font-size:13px; color:{OVERFLOW_COLOR}; margin-top:4px;">⚠ Aucune capacité de stockage (construisez un Entrepôt)</div>
+						{:else if over > 0}
+							<div style="font-size:13px; color:{OVERFLOW_COLOR}; margin-top:4px;">⚠ Surplus : +{over.toLocaleString('fr-FR')} au-delà de la capacité de stockage</div>
+						{/if}
 					</div>
 				{/each}
 			</div>

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -27,6 +27,9 @@
 
 	let pageIndex = $state(0)
 	let pageSize = $state(10)
+	// Drive the citizens table from local state: reassigning the SvelteKit `data`
+	// prop's nested promise is NOT reactive in Svelte 5, so the table never updated.
+	let peoplePromise = $state<Promise<PeopleType[]>>(data.lazy.people)
 
 	// Which panel is expanded: null = closed
 	type Panel = 'resources' | 'population' | 'jobs' | 'gender' | null
@@ -36,18 +39,18 @@
 	const closePanel = () => { activePanel = null }
 
 	const retrievePeople = async (newPageIndex: number, newPageSize: number) => {
-		const oldPeople = await data.lazy.people
+		const previous = peoplePromise
 		pageIndex = newPageIndex
 		pageSize = newPageSize
-		data.lazy.people = new Promise(async (resolve) => {
+		peoplePromise = (async () => {
 			try {
-				const { people } = await callGetPeople(data.civilization.id, pageIndex, pageSize)
-				resolve(people)
+				const { people } = await callGetPeople(data.civilization.id, newPageIndex, newPageSize)
+				return people
 			} catch (error) {
 				console.error(error)
-				resolve(oldPeople)
+				return previous
 			}
-		})
+		})()
 	}
 
 	// Live refresh: the world advances a month every ~15 min server-side. Subscribe
@@ -58,11 +61,10 @@
 		}
 		const source = new EventSource(`${PUBLIC_BACK_URL}/worlds/${data.worldId}/events`)
 		source.addEventListener('month', async () => {
+			// Refresh civilization stats/resources (data is replaced -> reactive) and
+			// re-fetch the citizens page currently shown.
 			await invalidateAll()
-			// invalidateAll reloads page-0 citizens; refresh the page being viewed.
-			if (pageIndex !== 0) {
-				retrievePeople(pageIndex, pageSize)
-			}
+			retrievePeople(pageIndex, pageSize)
 		})
 		return () => source.close()
 	})
@@ -602,7 +604,7 @@
 		<!-- People table -->
 		<div class="civ-inner-card" style="margin-top:20px;">
 			<h2 class="civ-section-title">Citoyens ({data.civilization.citizensCount} au total)</h2>
-			{#await data.lazy.people}
+			{#await peoplePromise}
 				<div style="height:120px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 			{:then people}
 				<PeopleTable

--- a/apps/front/src/routes/my-civilizations/[slug]/combats/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/combats/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PageData } from './$types'
+  import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 
   interface Props {
     data: PageData;
@@ -29,13 +30,13 @@
 
 <div class="civ-page-wrapper">
   <div style="animation:screenIn .46s cubic-bezier(.22,.72,.2,1) .05s both;">
-    <div style="font-size:15px; color:oklch(0.55 0.03 50); margin-bottom:20px;">
-      <a href="/my-civilizations/{data.slug}" style="color:oklch(0.5 0.1 40); text-decoration:none;">{data.civilization.name}</a>
-      <span style="margin:0 6px;">›</span>
-      <span>Journal des conflits</span>
-    </div>
+    <Breadcrumb items={[
+      { label: 'Mes civilisations', href: '/my-civilizations' },
+      { label: data.civilization.name, href: `/my-civilizations/${data.slug}` },
+      { label: 'Journal des conflits' }
+    ]} />
 
-    <h1 style="font-family:'Marcellus',serif; font-size:clamp(26px,4vw,36px); margin:0 0 24px; color:oklch(0.3 0.04 40);">Journal des conflits</h1>
+    <h1 style="font-family:'Tangerine',cursive; font-size:clamp(26px,4vw,36px); margin:0 0 24px; color:oklch(0.3 0.04 40);">Journal des conflits</h1>
 
     <div class="civ-inner-card">
       {#if data.logs.length === 0}

--- a/apps/front/src/routes/my-civilizations/[slug]/config/+page.server.ts
+++ b/apps/front/src/routes/my-civilizations/[slug]/config/+page.server.ts
@@ -79,8 +79,27 @@ export const actions: Actions = {
 				nextBuildingToBuild: form.data.nextBuildingToBuild
 			})
 
-			message(form, { status: 'success', text: 'La configuration a bien été mise à jour' })
-			return { form }
+			// Re-read so the form reflects exactly what was persisted (avoids showing
+			// stale/default values after submit).
+			const updated = await getMyCivilizationFromId(cookies.get('auth') ?? '', params.slug).catch(
+				() => null
+			)
+			const persistedForm = updated
+				? await superValidate(
+						{
+							maximumChildren: updated.config.MAXIMUM_CHILDREN,
+							maxActivePeopleByCivilization: updated.config.MAX_ACTIVE_PEOPLE_BY_CIVILIZATION,
+							openExchange: updated.config.OPEN_EXCHANGE ?? [],
+							militaryRatio: updated.config.MILITARY_RATIO,
+							atWarWith: updated.config.AT_WAR_WITH ?? [],
+							nextBuildingToBuild: updated.config.NEXT_BUILDING_TO_BUILD ?? null
+						},
+						zod(civilizationConfigSchema)
+					)
+				: form
+
+			message(persistedForm, { status: 'success', text: 'La configuration a bien été mise à jour' })
+			return { form: persistedForm }
 		} catch (requestError) {
 			error(requestError.status ?? 500, requestError.value ?? 'Une erreur est survenue')
 		}

--- a/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
@@ -16,6 +16,7 @@
 	import { toast } from 'svelte-sonner'
 	import { BuildingTypes } from '@ajustor/simulation'
 	import { buildingNames } from '$lib/translations'
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 
 	interface Props {
 		data: PageData;
@@ -24,6 +25,9 @@
 	let { data }: Props = $props();
 
 	const form = superForm(data.configForm, {
+		// openExchange / atWarWith are arrays driven by checkboxes (no native form
+		// inputs), so they only reach the server when the whole form is posted as JSON.
+		dataType: 'json',
 		validators: zodClient(civilizationConfigSchema),
 		onError({ result }) {
 			toast.error(result.error?.message ?? 'Une erreur est survenue')
@@ -60,10 +64,14 @@
 </svelte:head>
 
 <div class="civ-page-wrapper">
-<a href="/my-civilizations/{data.civilization.id}" style="background:none; border:none; cursor:pointer; font-family:'EB Garamond',serif; font-size:16px; color:oklch(0.5 0.06 40); padding:0; margin-bottom:14px; display:inline-flex; align-items:center; gap:6px; text-decoration:none; animation:screenIn .4s ease both;">‹ Retour à {data.civilization.name}</a>
+<Breadcrumb items={[
+	{ label: 'Mes civilisations', href: '/my-civilizations' },
+	{ label: data.civilization.name, href: `/my-civilizations/${data.civilization.id}` },
+	{ label: 'Configuration' }
+]} />
 
 <div class="civ-card" style="max-width:720px; margin:0 auto; display:flex; flex-direction:column; gap:20px;">
-	<h1 style="font-family:'Marcellus',serif; font-size:clamp(26px,4vw,36px); margin:0; color:oklch(0.3 0.04 40);">Configuration de {data.civilization.name}</h1>
+	<h1 style="font-family:'Tangerine',cursive; font-size:clamp(26px,4vw,36px); margin:0; color:oklch(0.3 0.04 40);">Configuration de {data.civilization.name}</h1>
 
 	<form method="post" use:formEnhance action="?/updateConfig" class="flex flex-col gap-4">
 

--- a/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
@@ -40,6 +40,10 @@
 		// openExchange / atWarWith are arrays driven by checkboxes (no native form
 		// inputs), so they only reach the server when the whole form is posted as JSON.
 		dataType: 'json',
+		// Keep the just-submitted values on screen instead of resetting to the
+		// initial (often default) load snapshot — the action returns the freshly
+		// persisted config, which we want to remain displayed.
+		resetForm: false,
 		validators: zodClient(civilizationConfigSchema),
 		onError({ result }) {
 			toast.error(result.error?.message ?? 'Une erreur est survenue')

--- a/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
@@ -14,8 +14,20 @@
 	import { zodClient } from 'sveltekit-superforms/adapters'
 	import { civilizationConfigSchema } from '$lib/schemas/civilizationConfig'
 	import { toast } from 'svelte-sonner'
-	import { BuildingTypes } from '@ajustor/simulation'
-	import { buildingNames } from '$lib/translations'
+	import {
+		BuildingTypes,
+		House,
+		Farm,
+		Kiln,
+		Sawmill,
+		Mine,
+		Campfire,
+		Cache,
+		Wall,
+		type ResourceTypes,
+		type OccupationTypes
+	} from '@ajustor/simulation'
+	import { buildingNames, resourceNames, OCCUPATIONS } from '$lib/translations'
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 
 	interface Props {
@@ -56,6 +68,35 @@
 			$formData.atWarWith = $formData.atWarWith.filter((id) => id !== civilizationId)
 		}
 	}
+
+	// Construction requirements come from the static fields on each building class.
+	type BuildingMeta = {
+		constructionCosts?: { resource: ResourceTypes; amount: number }[]
+		workerRequiredToBuild?: { occupation: OccupationTypes; amount: number }[]
+		timeToBuild?: number
+	}
+	const BUILDING_CLASSES: Record<BuildingTypes, BuildingMeta> = {
+		[BuildingTypes.HOUSE]: House,
+		[BuildingTypes.FARM]: Farm,
+		[BuildingTypes.KILN]: Kiln,
+		[BuildingTypes.SAWMILL]: Sawmill,
+		[BuildingTypes.MINE]: Mine,
+		[BuildingTypes.CAMPFIRE]: Campfire,
+		[BuildingTypes.CACHE]: Cache,
+		[BuildingTypes.WALL]: Wall
+	}
+
+	const selectedBuildingInfo = $derived.by(() => {
+		const type = $formData.nextBuildingToBuild
+		if (!type) return null
+		const meta = BUILDING_CLASSES[type as BuildingTypes]
+		if (!meta) return null
+		return {
+			costs: meta.constructionCosts ?? [],
+			workers: meta.workerRequiredToBuild ?? [],
+			timeToBuild: meta.timeToBuild
+		}
+	})
 </script>
 
 <svelte:head>
@@ -181,6 +222,36 @@
 						{/snippet}
 					</FormControl>
 					<FormDescription>Bâtiment que la civilisation cherchera à construire en priorité.</FormDescription>
+					{#if selectedBuildingInfo}
+						<div style="margin-top:10px; padding:12px 14px; border:1px solid oklch(0.8 0.04 70); border-radius:4px; background:oklch(0.97 0.015 84); display:flex; flex-direction:column; gap:10px;">
+							<div style="display:flex; align-items:baseline; gap:8px;">
+								<span style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50);">Temps de construction</span>
+								<span style="font-size:15px; font-weight:600; color:oklch(0.32 0.04 40);">{selectedBuildingInfo.timeToBuild ?? '?'} mois</span>
+							</div>
+							<div>
+								<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Ressources requises</div>
+								{#if selectedBuildingInfo.costs.length}
+									<div style="display:flex; flex-wrap:wrap; gap:6px;">
+										{#each selectedBuildingInfo.costs as cost}
+											<span style="font-size:14px; padding:3px 10px; border-radius:3px; background:oklch(0.92 0.03 78); color:oklch(0.35 0.04 42);">{cost.amount} {resourceNames[cost.resource]}</span>
+										{/each}
+									</div>
+								{:else}
+									<span style="font-size:14px; color:oklch(0.5 0.03 50);">Aucune ressource requise</span>
+								{/if}
+							</div>
+							{#if selectedBuildingInfo.workers.length}
+								<div>
+									<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Ouvriers requis pour la construction</div>
+									<div style="display:flex; flex-wrap:wrap; gap:6px;">
+										{#each selectedBuildingInfo.workers as worker}
+											<span style="font-size:14px; padding:3px 10px; border-radius:3px; background:oklch(0.92 0.03 78); color:oklch(0.35 0.04 42);">{worker.amount} {OCCUPATIONS[worker.occupation]}</span>
+										{/each}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
 					<FormFieldErrors />
 				</FormField>
 			</div>

--- a/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
@@ -204,6 +204,13 @@
 					<p style="color:oklch(0.5 0.03 50);">Aucune autre civilisation dans ce monde.</p>
 				{/if}
 
+				</div>
+			</div>
+
+			<!-- Construction -->
+			<div class="civ-inner-card">
+				<h3 class="civ-section-title">Construction</h3>
+				<div style="display:flex; flex-direction:column; gap:16px;">
 				<FormField {form} name="nextBuildingToBuild">
 					<FormControl>
 						{#snippet children({ props })}

--- a/apps/front/src/routes/my-civilizations/[slug]/datatables/people-table.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/datatables/people-table.svelte
@@ -5,7 +5,7 @@
 	import ChildDetails from './childDetails.svelte'
 	import { ArrowUp, ArrowDown, ArrowUpDown } from '@lucide/svelte'
 
-	type SortKey = 'gender' | 'years' | 'lifeCounter' | 'occupation'
+	type SortKey = 'name' | 'gender' | 'years' | 'lifeCounter' | 'occupation'
 	type SortOrder = 'asc' | 'desc' | null
 
 	type Props = {
@@ -62,6 +62,7 @@
 	})
 
 	const sortableColumns: { key: SortKey; header: string }[] = [
+		{ key: 'name', header: 'Nom' },
 		{ key: 'gender', header: 'Genre' },
 		{ key: 'years', header: 'Age' },
 		{ key: 'lifeCounter', header: 'Points de vie' },
@@ -121,6 +122,7 @@
 		<tbody>
 			{#each sortedPeople as person (person.id ?? Math.random())}
 				<tr style="border-bottom:1px solid oklch(0.88 0.03 70);">
+					<td style="padding:8px 12px;">{person.name ?? '—'}</td>
 					<td style="padding:8px 12px;">
 						{#if person.gender}
 							<Icon icon={GenderIcons[person.gender]} />

--- a/apps/front/src/routes/my-civilizations/[slug]/people/+server.ts
+++ b/apps/front/src/routes/my-civilizations/[slug]/people/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit'
+import { getPeopleFromCivilizationPaginated } from '../../../../services/api/people-api.js'
+
+export const prerender = false
+
+// Dedicated JSON endpoint for paginated citizens. Lives on its own route (no
+// sibling +page) so it always returns JSON — unlike the parent /[slug] route,
+// where a +page and a +server compete via content negotiation.
+export async function GET({ cookies, params, url }) {
+  const page = +(url.searchParams.get('page') ?? '0')
+  const count = +(url.searchParams.get('count') ?? '10')
+
+  const people = await getPeopleFromCivilizationPaginated(cookies.get('auth') ?? '', params.slug, {
+    page,
+    count,
+  })
+
+  return json({ people }, { status: 200 })
+}

--- a/apps/front/src/routes/register/+page.server.ts
+++ b/apps/front/src/routes/register/+page.server.ts
@@ -20,7 +20,16 @@ export const actions: Actions = {
         form,
       })
     }
-    await createNewUser(form.data.email, form.data.password, form.data.username).catch(error => message(form, { status: 'error', text: error.value }, error))
+    try {
+      await createNewUser(form.data.email, form.data.password, form.data.username)
+    } catch (error) {
+      // Surface the real failure instead of silently redirecting to /login.
+      return message(
+        form,
+        { status: 'error', text: (error as { value?: string })?.value ?? 'Impossible de créer le compte' },
+        { status: 409 }
+      )
+    }
 
     throw redirect(302, '/login')
   }

--- a/apps/front/src/routes/register/+page.svelte
+++ b/apps/front/src/routes/register/+page.svelte
@@ -35,8 +35,8 @@
 	<div style="width:min(440px,100%); padding:clamp(28px,5vw,44px); border-radius:5px; background:radial-gradient(circle at 18% 12%, rgba(150,110,60,.07), transparent 45%), oklch(0.95 0.022 84); border:1px solid oklch(0.78 0.045 70); box-shadow:inset 0 0 0 6px oklch(0.93 0.03 84), inset 0 0 0 7px oklch(0.74 0.05 60), 0 22px 60px rgba(60,40,20,.22); animation:loginIn .5s cubic-bezier(.22,.72,.2,1) both;">
 		<!-- Logo + Brand -->
 		<div style="display:flex; flex-direction:column; align-items:center; text-align:center; margin-bottom:26px;">
-			<div style="width:72px; height:72px; border-radius:50%; background:radial-gradient(circle at 35% 30%, oklch(0.55 0.14 38), oklch(0.4 0.13 34)); color:oklch(0.94 0.03 84); display:flex; align-items:center; justify-content:center; font-family:'Marcellus',serif; font-size:34px; box-shadow:0 6px 16px rgba(80,30,20,.3), inset 0 2px 6px rgba(255,220,180,.4);">C</div>
-			<h1 style="font-family:'Marcellus',serif; font-size:38px; margin:18px 0 4px; color:oklch(0.3 0.04 40);">Civilizations</h1>
+			<div style="width:72px; height:72px; border-radius:50%; background:radial-gradient(circle at 35% 30%, oklch(0.55 0.14 38), oklch(0.4 0.13 34)); color:oklch(0.94 0.03 84); display:flex; align-items:center; justify-content:center; font-family:'Tangerine',cursive; font-size:34px; box-shadow:0 6px 16px rgba(80,30,20,.3), inset 0 2px 6px rgba(255,220,180,.4);">C</div>
+			<h1 style="font-family:'Tangerine',cursive; font-size:38px; margin:18px 0 4px; color:oklch(0.3 0.04 40);">Civilizations</h1>
 		</div>
 
 		<!-- Auth tabs -->

--- a/apps/front/src/routes/rules/+page.svelte
+++ b/apps/front/src/routes/rules/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte'
 	import { getWorldsInfos } from '../../services/api/world-api'
-	import { resourceNames, eventsName } from '$lib/translations'
+	import { resourceNames, eventsName, eventsDescription } from '$lib/translations'
 	import { type ResourceTypes, type Events } from '@ajustor/simulation'
 
 	type WorldInfo = Awaited<ReturnType<typeof getWorldsInfos>>[number]
@@ -24,7 +24,7 @@
 	const selectedWorld = $derived(worlds.find((w) => w.id === selectedWorldId) ?? null)
 
 	// Seasonal resource multipliers — mirror the values applied in the simulation
-	// (World.passResources). Generation = base config × multiplier.
+	// (World.passAMonth). Generation = base config × multiplier.
 	const SEASONS = [
 		{ name: 'Printemps', months: [0, 1, 2], food: 1.5, wood: 1.1, color: 'oklch(0.52 0.1 130)' },
 		{ name: 'Été', months: [3, 4, 5], food: 1.75, wood: 1.2, color: 'oklch(0.6 0.12 70)' },
@@ -37,6 +37,33 @@
 		selectedWorld ? SEASONS.find((s) => s.months.includes(selectedWorld.month)) ?? null : null
 	)
 	const civilizationsCount = $derived(selectedWorld?.civilizations?.length ?? 0)
+
+	// ── Données de règles (valeurs issues de la simulation) ────────────────────
+	const OCCUPATION_RULES = [
+		{ name: 'Enfant', age: 'dès 4 ans (peut évoluer à 12 ans)', eat: 1, role: 'Récolte 5 nourriture ou pierre par mois' },
+		{ name: 'Récolteur', age: "jusqu'à 70 ans", eat: 2, role: 'Récolte 20 nourriture ou pierre par mois' },
+		{ name: 'Coupeur de bois', age: "jusqu'à 60 ans", eat: 2, role: 'Récolte 10 bois par mois' },
+		{ name: 'Fermier', age: "jusqu'à 70 ans", eat: 3, role: 'Exploite une Ferme (jusqu’à 100 nourriture / mois)' },
+		{ name: 'Charpentier', age: "jusqu'à 60 ans", eat: 3, role: 'Exploite une Scierie (produit des planches)' },
+		{ name: 'Charbonnier', age: '12 à 60 ans', eat: 3, role: 'Exploite un Four à chaux (produit du charbon)' },
+		{ name: 'Commis de cuisine', age: "jusqu'à 70 ans", eat: 2, role: 'Exploite un Feu de camp (produit de la nourriture préparée)' },
+		{ name: 'Mineur', age: "jusqu'à 50 ans", eat: 3, role: 'Exploite une Mine (produit de la pierre)' },
+		{ name: 'Soldat', age: "jusqu'à 60 ans", eat: 3, role: 'Défend la civilisation et mène les attaques' },
+		{ name: 'Retraité', age: 'après la vie active', eat: 1, role: 'Ne travaille plus' }
+	]
+
+	const BUILDING_RULES = [
+		{ name: 'Maison', cost: '15 bois', time: '2 mois', build: '—', operate: '—', effect: 'Loge 4 citoyens (un logement évite la perte de point de vie)' },
+		{ name: 'Ferme', cost: '10 planches + 10 pierre', time: '2 mois', build: '2 récolteurs', operate: '5 fermiers', effect: 'Produit 100 nourriture / mois' },
+		{ name: 'Four à chaux', cost: '20 pierre', time: '4 mois', build: '2 coupeurs de bois', operate: '2 charbonniers', effect: '5 bois → 10 charbon' },
+		{ name: 'Scierie', cost: '15 pierre', time: '4 mois', build: '—', operate: '2 charpentiers', effect: '1 bois → 5 planches' },
+		{ name: 'Mine', cost: 'aucun', time: '10 mois', build: '5 récolteurs', operate: '10 mineurs', effect: 'Produit de la pierre (1 à 100 par mineur)' },
+		{ name: 'Feu de camp', cost: '15 bois', time: '2 mois', build: '2 récolteurs', operate: '1 commis de cuisine', effect: '10 nourriture → 7 nourriture préparée' },
+		{ name: 'Entrepôt', cost: 'aucun', time: '1 mois', build: '1 récolteur', operate: '—', effect: 'Stocke et protège les ressources (nourriture 300, pierre 300, bois 150, charbon 150, planches 150, nourriture préparée 100). Indestructible.' },
+		{ name: 'Muraille', cost: '2000 pierre + 1500 bois', time: '12 mois', build: '250 bâtisseurs', operate: '—', effect: 'Bloque une attaque entière, puis est détruite' }
+	]
+
+	const eventEntries = Object.entries(eventsName) as [Events, string][]
 </script>
 
 <svelte:head>
@@ -146,8 +173,8 @@
 			<section class="civ-inner-card">
 				<h2 class="civ-section-title">Le temps qui passe</h2>
 				<ul style="list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; font-size:17px; line-height:1.6; color:oklch(0.42 0.03 50);">
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>Toutes les 15 minutes, un mois passe dans le monde.</li>
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>Un cycle complet de 12 mois correspond à une année. Les saisons se succèdent ainsi : <strong>printemps</strong> (mois 0–2), <strong>été</strong> (3–5), <strong>automne</strong> (6–8), <strong>hiver</strong> (9–11).</li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Toutes les 15 minutes, un mois passe dans le monde.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Un cycle complet de 12 mois correspond à une année. Les saisons se succèdent ainsi : <strong>printemps</strong> (mois 0–2), <strong>été</strong> (3–5), <strong>automne</strong> (6–8), <strong>hiver</strong> (9–11).</span></li>
 				</ul>
 			</section>
 
@@ -155,10 +182,13 @@
 			<section class="civ-inner-card">
 				<h2 class="civ-section-title">Survie des citoyens</h2>
 				<ul style="list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; font-size:17px; line-height:1.6; color:oklch(0.42 0.03 50);">
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>Chaque mois, les citoyens doivent <strong>manger</strong> et disposer d'un <strong>logement</strong> pour rester en vie.</li>
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>En automne et en hiver, ils ont également besoin de <strong>bois</strong> pour se chauffer.</li>
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>Un citoyen ayant atteint 85 ans a <strong>20 % de chances de mourir</strong> chaque mois.</li>
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>La population d'une civilisation est <strong>limitée à 100 000 habitants</strong> (hors retraités).</li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Chaque citoyen a une jauge de <strong>points de vie</strong> (12 au maximum). Elle monte quand il mange et baisse quand il manque de l'essentiel.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span><strong>Nourriture</strong> : la nourriture préparée est consommée en priorité (rend de la vie). À défaut, la nourriture brute est consommée en plus grande quantité pour un effet moindre. Le besoin dépend du métier (de 1 à 3 par mois).</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Sans aucune nourriture, un citoyen perd <strong>4 points de vie</strong> dans le mois.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span><strong>Logement</strong> : une Maison loge 4 citoyens. Un citoyen sans logement perd <strong>1 point de vie</strong> par mois.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span><strong>Chauffage</strong> : en automne (2 bois/personne) et en hiver (3 bois/personne), il faut se chauffer. Le charbon est plus efficace : 1 charbon chauffe 10 personnes. Un citoyen non chauffé perd <strong>1 point de vie</strong> par mois.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>À partir de <strong>85 ans</strong>, un citoyen a <strong>20 % de chances de mourir</strong> chaque mois.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Le nombre d'actifs d'une civilisation est <strong>plafonné</strong> (100 000 par défaut, configurable).</span></li>
 				</ul>
 			</section>
 
@@ -166,27 +196,96 @@
 			<section class="civ-inner-card">
 				<h2 class="civ-section-title">Reproduction</h2>
 				<ul style="list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; font-size:17px; line-height:1.6; color:oklch(0.42 0.03 50);">
-					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span>Les citoyens peuvent se reproduire chaque mois à condition d'avoir une <strong>santé d'au moins 8</strong> et d'être âgés de <strong>16 à 60 ans</strong>.</li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Pour concevoir, un citoyen doit avoir entre <strong>16 et 50 ans</strong>, une <strong>santé d'au moins 8</strong>, et ne pas déjà attendre d'enfant.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Une <strong>grossesse dure 9 mois</strong>. Chaque citoyen peut avoir jusqu'à <strong>3 enfants</strong> au cours de sa vie.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Chaque mois, un couple éligible a une <strong>probabilité de conception</strong> (60 % par défaut, configurable).</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Le nombre d'enfants à naître <strong>simultanément</strong> dans la civilisation est limité (10 par défaut, configurable).</span></li>
 				</ul>
 			</section>
 
 			<!-- Métiers -->
 			<section class="civ-inner-card">
 				<h2 class="civ-section-title">Métiers</h2>
-				<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:12px; font-size:16px; color:oklch(0.42 0.03 50);">
-					<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px;">
-						<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40); margin-bottom:4px;">Fermier</div>
-						<div>Travaille de 4 à 70 ans · consomme 1 de nourriture</div>
-					</div>
-					<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px;">
-						<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40); margin-bottom:4px;">Charpentier</div>
-						<div>Travaille de 12 à 60 ans · consomme 2 de nourriture</div>
-					</div>
+				<p style="font-size:15px; color:oklch(0.5 0.03 50); margin:0 0 14px;">
+					Les enfants, récolteurs et coupeurs de bois peuvent <strong>évoluer</strong> vers un métier spécialisé (20 % de chance par mois). Les métiers spécialisés font fonctionner les bâtiments de production.
+				</p>
+				<div style="overflow-x:auto;">
+					<table style="width:100%; border-collapse:collapse; font-family:'EB Garamond',serif; font-size:15px; color:oklch(0.4 0.03 50);">
+						<thead>
+							<tr style="border-bottom:2px solid oklch(0.78 0.04 70);">
+								<th style="text-align:left; padding:8px 12px; font-family:'Marcellus',serif; font-weight:400; color:oklch(0.45 0.05 50);">Métier</th>
+								<th style="text-align:left; padding:8px 12px; font-family:'Marcellus',serif; font-weight:400; color:oklch(0.45 0.05 50);">Travaille</th>
+								<th style="text-align:center; padding:8px 12px; font-family:'Marcellus',serif; font-weight:400; color:oklch(0.45 0.05 50);">Nourriture / mois</th>
+								<th style="text-align:left; padding:8px 12px; font-family:'Marcellus',serif; font-weight:400; color:oklch(0.45 0.05 50);">Rôle</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each OCCUPATION_RULES as job}
+								<tr style="border-bottom:1px solid oklch(0.88 0.03 70);">
+									<td style="padding:8px 12px; font-family:'Marcellus',serif; color:oklch(0.34 0.04 40);">{job.name}</td>
+									<td style="padding:8px 12px;">{job.age}</td>
+									<td style="padding:8px 12px; text-align:center;">{job.eat}</td>
+									<td style="padding:8px 12px;">{job.role}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
 				</div>
-				<div style="margin-top:12px; padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; font-size:16px; color:oklch(0.42 0.03 50);">
-					<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40); margin-bottom:4px;">Bâtiments</div>
-					<div>Une <strong>Maison</strong> aide les citoyens à rester en vie en assurant un logement.</div>
+			</section>
+
+			<!-- Bâtiments -->
+			<section class="civ-inner-card">
+				<h2 class="civ-section-title">Bâtiments</h2>
+				<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:12px;">
+					{#each BUILDING_RULES as b}
+						<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; display:flex; flex-direction:column; gap:6px;">
+							<div style="font-family:'Marcellus',serif; font-size:19px; color:oklch(0.34 0.04 40);">{b.name}</div>
+							<div style="font-size:15px; color:oklch(0.42 0.03 50);">{b.effect}</div>
+							<div style="display:grid; grid-template-columns:auto 1fr; gap:2px 10px; font-size:14px; color:oklch(0.5 0.03 50); margin-top:4px;">
+								<span style="color:oklch(0.55 0.04 55);">Coût</span><span>{b.cost}</span>
+								<span style="color:oklch(0.55 0.04 55);">Durée</span><span>{b.time}</span>
+								<span style="color:oklch(0.55 0.04 55);">Construit par</span><span>{b.build}</span>
+								<span style="color:oklch(0.55 0.04 55);">Exploité par</span><span>{b.operate}</span>
+							</div>
+						</div>
+					{/each}
 				</div>
+			</section>
+
+			<!-- Événements -->
+			<section class="civ-inner-card">
+				<h2 class="civ-section-title">Événements</h2>
+				<p style="font-size:15px; color:oklch(0.5 0.03 50); margin:0 0 14px;">
+					Chaque mois, selon la <strong>probabilité d'événement</strong> du monde, un événement peut frapper les civilisations. Les ressources stockées dans un <strong>Entrepôt</strong> sont protégées de l'incendie et de l'invasion de rats.
+				</p>
+				<div style="display:flex; flex-direction:column; gap:10px;">
+					{#each eventEntries as [event, name]}
+						<div style="padding:12px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; border-left:3px solid oklch(0.5 0.16 30);">
+							<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40); margin-bottom:2px;">{name}</div>
+							<div style="font-size:15px; color:oklch(0.42 0.03 50);">{eventsDescription[event]}</div>
+						</div>
+					{/each}
+				</div>
+			</section>
+
+			<!-- Guerre & combat -->
+			<section class="civ-inner-card">
+				<h2 class="civ-section-title">Guerre &amp; combat</h2>
+				<ul style="list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; font-size:17px; line-height:1.6; color:oklch(0.42 0.03 50);">
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Le <strong>ratio militaire</strong> (configurable) définit la part des adultes (hors enfants et retraités) entretenus comme <strong>soldats</strong>.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Lors d'une bataille, la <strong>force</strong> de chaque camp est la somme des points de vie de ses soldats. Le camp le plus fort l'emporte ; les pertes sont proportionnelles à la force adverse.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>En cas de victoire, l'attaquant <strong>pille 25 %</strong> de chaque ressource et <strong>capture 5 %</strong> de la population adverse (100 captifs maximum).</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Une <strong>Muraille</strong> bloque entièrement une attaque, mais elle est détruite dans l'opération.</span></li>
+				</ul>
+			</section>
+
+			<!-- Échanges -->
+			<section class="civ-inner-card">
+				<h2 class="civ-section-title">Échanges entre civilisations</h2>
+				<ul style="list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; font-size:17px; line-height:1.6; color:oklch(0.42 0.03 50);">
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>L'échange n'a lieu que s'il est <strong>mutuel</strong> : les deux civilisations doivent s'ajouter l'une l'autre dans leur configuration.</span></li>
+					<li style="display:flex; gap:12px;"><span style="color:oklch(0.5 0.13 34); flex-shrink:0;">·</span><span>Chaque mois, pour chaque ressource, leurs stocks sont <strong>rapprochés de leur moyenne</strong> — la civilisation la mieux pourvue aide la plus démunie.</span></li>
+				</ul>
 			</section>
 
 		</div>

--- a/apps/front/src/routes/rules/+page.svelte
+++ b/apps/front/src/routes/rules/+page.svelte
@@ -7,7 +7,7 @@
 	<div class="civ-card civ-animate-in">
 		<div style="border-bottom:2px solid oklch(0.72 0.05 60); padding-bottom:20px; margin-bottom:28px;">
 			<div style="font-family:'Marcellus',serif; font-size:13px; letter-spacing:.4em; text-transform:uppercase; color:oklch(0.5 0.09 40); margin-bottom:6px;">Simulation</div>
-			<h1 style="font-family:'Marcellus',serif; font-size:clamp(34px,6vw,46px); margin:0; color:oklch(0.3 0.04 40);">Les règles du monde</h1>
+			<h1 style="font-family:'Tangerine',cursive; font-size:clamp(34px,6vw,46px); margin:0; color:oklch(0.3 0.04 40);">Les règles du monde</h1>
 		</div>
 
 		<div style="display:flex; flex-direction:column; gap:24px;">

--- a/apps/front/src/routes/rules/+page.svelte
+++ b/apps/front/src/routes/rules/+page.svelte
@@ -1,3 +1,44 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import { getWorldsInfos } from '../../services/api/world-api'
+	import { resourceNames, eventsName } from '$lib/translations'
+	import { type ResourceTypes, type Events } from '@ajustor/simulation'
+
+	type WorldInfo = Awaited<ReturnType<typeof getWorldsInfos>>[number]
+
+	let worlds = $state<WorldInfo[]>([])
+	let selectedWorldId = $state<string>('')
+	let loading = $state(true)
+
+	onMount(async () => {
+		try {
+			worlds = (await getWorldsInfos()) ?? []
+			selectedWorldId = worlds[0]?.id ?? ''
+		} catch (error) {
+			console.error(error)
+		} finally {
+			loading = false
+		}
+	})
+
+	const selectedWorld = $derived(worlds.find((w) => w.id === selectedWorldId) ?? null)
+
+	// Seasonal resource multipliers — mirror the values applied in the simulation
+	// (World.passResources). Generation = base config × multiplier.
+	const SEASONS = [
+		{ name: 'Printemps', months: [0, 1, 2], food: 1.5, wood: 1.1, color: 'oklch(0.52 0.1 130)' },
+		{ name: 'Été', months: [3, 4, 5], food: 1.75, wood: 1.2, color: 'oklch(0.6 0.12 70)' },
+		{ name: 'Automne', months: [6, 7, 8], food: 1.2, wood: 1, color: 'oklch(0.55 0.1 50)' },
+		{ name: 'Hiver', months: [9, 10, 11], food: 0.5, wood: 0.75, color: 'oklch(0.5 0.05 240)' }
+	]
+
+	const fmt = (n: number) => Math.round(n).toLocaleString('fr-FR')
+	const currentSeason = $derived(
+		selectedWorld ? SEASONS.find((s) => s.months.includes(selectedWorld.month)) ?? null : null
+	)
+	const civilizationsCount = $derived(selectedWorld?.civilizations?.length ?? 0)
+</script>
+
 <svelte:head>
 	<title>Les règles — Civilizations</title>
 	<meta name="description" content="Les règles de la simulation de civilisation" />
@@ -10,6 +51,95 @@
 			<h1 style="font-family:'Tangerine',cursive; font-size:clamp(34px,6vw,46px); margin:0; color:oklch(0.3 0.04 40);">Les règles du monde</h1>
 		</div>
 
+		<!-- Sélecteur de monde -->
+		<div class="civ-inner-card" style="margin-bottom:24px;">
+			<h2 class="civ-section-title">Choisir un monde</h2>
+			{#if loading}
+				<p style="color:oklch(0.5 0.03 50); font-size:16px;">Chargement des mondes…</p>
+			{:else if worlds.length === 0}
+				<p style="color:oklch(0.5 0.03 50); font-size:16px;">Aucun monde disponible pour le moment.</p>
+			{:else}
+				<select
+					bind:value={selectedWorldId}
+					style="width:100%; max-width:360px; padding:10px 14px; border:1px solid oklch(0.74 0.05 60); border-radius:4px; background:oklch(0.98 0.01 84); color:oklch(0.3 0.04 40); font-family:'EB Garamond',serif; font-size:16px;"
+				>
+					{#each worlds as world}
+						<option value={world.id}>{world.name}</option>
+					{/each}
+				</select>
+			{/if}
+		</div>
+
+		{#if selectedWorld}
+			<!-- État actuel du monde -->
+			<section class="civ-inner-card" style="margin-bottom:24px;">
+				<h2 class="civ-section-title">État de {selectedWorld.name}</h2>
+				<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:12px;">
+					<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px;">
+						<div style="font-size:11px; letter-spacing:.12em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Date</div>
+						<div style="font-family:'Marcellus',serif; font-size:20px; color:oklch(0.34 0.04 40);">An {selectedWorld.year} · Mois {selectedWorld.month + 1}</div>
+						{#if currentSeason}
+							<div style="font-size:15px; color:oklch(0.42 0.03 50); margin-top:2px;">Saison : <strong>{currentSeason.name}</strong></div>
+						{/if}
+					</div>
+					<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px;">
+						<div style="font-size:11px; letter-spacing:.12em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Civilisations</div>
+						<div style="font-family:'Marcellus',serif; font-size:20px; color:oklch(0.34 0.04 40);">{fmt(civilizationsCount)}</div>
+					</div>
+					<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px;">
+						<div style="font-size:11px; letter-spacing:.12em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Prochain événement</div>
+						<div style="font-family:'Marcellus',serif; font-size:20px; color:{selectedWorld.nextEvent ? 'oklch(0.5 0.16 30)' : 'oklch(0.34 0.04 40)'};">
+							{selectedWorld.nextEvent ? eventsName[selectedWorld.nextEvent as Events] : 'Aucun'}
+						</div>
+					</div>
+					<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px;">
+						<div style="font-size:11px; letter-spacing:.12em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Probabilité d'événement</div>
+						<div style="font-family:'Marcellus',serif; font-size:20px; color:oklch(0.34 0.04 40);">{selectedWorld.config.EVENT_CHANCE}%</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- Réserves actuelles du monde -->
+			{#if selectedWorld.resources?.length}
+				<section class="civ-inner-card" style="margin-bottom:24px;">
+					<h2 class="civ-section-title">Réserves actuelles de {selectedWorld.name}</h2>
+					<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:12px;">
+						{#each selectedWorld.resources as resource}
+							<div style="padding:12px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; display:flex; justify-content:space-between; align-items:baseline;">
+								<span style="font-size:16px; color:oklch(0.42 0.03 50);">{resourceNames[resource.type as ResourceTypes] ?? resource.type}</span>
+								<span style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40);">{fmt(resource.quantity)}</span>
+							</div>
+						{/each}
+					</div>
+				</section>
+			{/if}
+
+			<!-- Génération de ressources par saison (propre à ce monde) -->
+			<section class="civ-inner-card" style="margin-bottom:24px;">
+				<h2 class="civ-section-title">Génération de ressources par saison</h2>
+				<p style="font-size:15px; color:oklch(0.5 0.03 50); margin:0 0 12px;">
+					Chaque mois, {selectedWorld.name} produit ces quantités de base, modulées par la saison.
+				</p>
+				<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px;">
+					{#each SEASONS as s}
+						<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; border-top:3px solid {s.color}; {currentSeason?.name === s.name ? 'box-shadow:0 0 0 2px ' + s.color + ' inset;' : ''}">
+							<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
+								<span style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40);">{s.name}</span>
+								{#if currentSeason?.name === s.name}
+									<span style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:{s.color};">Actuelle</span>
+								{/if}
+							</div>
+							<div style="font-size:15px; color:oklch(0.42 0.03 50); display:flex; flex-direction:column; gap:4px;">
+								<span>Nourriture : <strong>{fmt(selectedWorld.config.BASE_FOOD_GENERATION * s.food)}</strong> <span style="color:oklch(0.55 0.03 50); font-size:13px;">(× {s.food})</span></span>
+								<span>Bois : <strong>{fmt(selectedWorld.config.BASE_WOOD_GENERATION * s.wood)}</strong> <span style="color:oklch(0.55 0.03 50); font-size:13px;">(× {s.wood})</span></span>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</section>
+		{/if}
+
+		<!-- Règles générales (communes à tous les mondes) -->
 		<div style="display:flex; flex-direction:column; gap:24px;">
 
 			<!-- Temps -->
@@ -56,27 +186,6 @@
 				<div style="margin-top:12px; padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; font-size:16px; color:oklch(0.42 0.03 50);">
 					<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40); margin-bottom:4px;">Bâtiments</div>
 					<div>Une <strong>Maison</strong> aide les citoyens à rester en vie en assurant un logement.</div>
-				</div>
-			</section>
-
-			<!-- Réserves du monde -->
-			<section class="civ-inner-card">
-				<h2 class="civ-section-title">Réserves du monde par saison</h2>
-				<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px;">
-					{#each [
-						{ name: 'Printemps', food: '× 1,5', wood: '× 1,1', color: 'oklch(0.52 0.1 130)' },
-						{ name: 'Été',       food: '× 1,75', wood: '× 1,2', color: 'oklch(0.6 0.12 70)' },
-						{ name: 'Automne',   food: '× 1,2',  wood: '× 1',   color: 'oklch(0.55 0.1 50)' },
-						{ name: 'Hiver',     food: '× 0,5',  wood: '× 0,75', color: 'oklch(0.5 0.05 240)' }
-					] as s}
-						<div style="padding:14px 16px; border:1px solid oklch(0.84 0.03 72); border-radius:4px; border-top:3px solid {s.color};">
-							<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40); margin-bottom:8px;">{s.name}</div>
-							<div style="font-size:15px; color:oklch(0.42 0.03 50); display:flex; flex-direction:column; gap:4px;">
-								<span>Nourriture {s.food}</span>
-								<span>Bois {s.wood}</span>
-							</div>
-						</div>
-					{/each}
 				</div>
 			</section>
 

--- a/apps/front/src/routes/worlds/[worldId]/market/+page.svelte
+++ b/apps/front/src/routes/worlds/[worldId]/market/+page.svelte
@@ -3,6 +3,7 @@
 	import { enhance } from '$app/forms'
 	import { ResourceTypes } from '@ajustor/simulation'
 	import { resourceNames } from '$lib/translations'
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 
 	let { data }: { data: PageData } = $props()
 
@@ -60,10 +61,13 @@
 </svelte:head>
 
 <div class="civ-page-wrapper">
-	<a href="/my-civilizations" style="background:none; border:none; cursor:pointer; font-family:'EB Garamond',serif; font-size:16px; color:oklch(0.5 0.06 40); padding:0; margin-bottom:14px; display:inline-block; text-decoration:none; animation:screenIn .4s ease both;">‹ Mes civilisations</a>
+	<Breadcrumb items={[
+		{ label: 'Mes civilisations', href: '/my-civilizations' },
+		{ label: 'Marché du monde' }
+	]} />
 
 	<div class="civ-card" style="animation:screenIn .46s cubic-bezier(.22,.72,.2,1) .05s both;">
-		<h1 style="font-family:'Marcellus',serif; font-size:clamp(28px,5vw,40px); margin:0 0 24px; color:oklch(0.3 0.04 40); border-bottom:2px solid oklch(0.72 0.05 60); padding-bottom:16px;">Marché du monde</h1>
+		<h1 style="font-family:'Tangerine',cursive; font-size:clamp(28px,5vw,40px); margin:0 0 24px; color:oklch(0.3 0.04 40); border-bottom:2px solid oklch(0.72 0.05 60); padding-bottom:16px;">Marché du monde</h1>
 
 		<!-- Créer une offre -->
 		<div class="civ-inner-card" style="margin-bottom:24px;">
@@ -160,20 +164,31 @@
 					{@const isMyOffer = myCivIds.has((offer as Offer).fromCivilizationId)}
 					<div class="civ-inner-card">
 						<div style="display:flex; flex-wrap:wrap; justify-content:space-between; align-items:flex-start; gap:12px;">
-							<div>
-								<div style="font-family:'Marcellus',serif; font-size:18px; color:oklch(0.34 0.04 40);">
-									{formatResources((offer as Offer).give)}
-									<span style="color:oklch(0.6 0.05 60); margin:0 8px;">→</span>
-									{formatResources((offer as Offer).want)}
-								</div>
-								<div style="margin-top:6px; font-size:14px; color:oklch(0.54 0.03 50);">
+							<div style="flex:1; min-width:240px;">
+								<div style="margin-bottom:8px; font-size:14px; color:oklch(0.54 0.03 50);">
 									De : <strong>{civName((offer as Offer).fromCivilizationId)}</strong>
 									{#if (offer as Offer).toCivilizationId}
-										· Pour : <strong>{civName((offer as Offer).toCivilizationId!)}</strong>
+										· Réservée à : <strong>{civName((offer as Offer).toCivilizationId!)}</strong>
 									{:else}
-										· <em>Offre ouverte</em>
+										· <em>Offre ouverte à tous</em>
 									{/if}
 								</div>
+								<div style="display:flex; flex-wrap:wrap; align-items:stretch; gap:10px;">
+									<div style="flex:1; min-width:140px; border:1px solid oklch(0.82 0.06 145); border-radius:4px; padding:8px 12px; background:oklch(0.96 0.03 145);">
+										<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.45 0.09 150); margin-bottom:2px;">Offre</div>
+										<div style="font-family:'Marcellus',serif; font-size:17px; color:oklch(0.34 0.05 145);">{formatResources((offer as Offer).give)}</div>
+									</div>
+									<div style="display:flex; align-items:center; color:oklch(0.6 0.05 60); font-size:20px;">⇄</div>
+									<div style="flex:1; min-width:140px; border:1px solid oklch(0.82 0.07 60); border-radius:4px; padding:8px 12px; background:oklch(0.97 0.03 70);">
+										<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.5 0.1 55); margin-bottom:2px;">En échange de</div>
+										<div style="font-family:'Marcellus',serif; font-size:17px; color:oklch(0.4 0.07 50);">{formatResources((offer as Offer).want)}</div>
+									</div>
+								</div>
+								{#if !isMyOffer}
+									<div style="margin-top:8px; font-size:13px; color:oklch(0.5 0.03 50); font-style:italic;">
+										En acceptant, vous donnez <strong style="font-style:normal; color:oklch(0.42 0.07 50);">{formatResources((offer as Offer).want)}</strong> et recevez <strong style="font-style:normal; color:oklch(0.4 0.07 145);">{formatResources((offer as Offer).give)}</strong>.
+									</div>
+								{/if}
 							</div>
 
 							<div style="display:flex; gap:8px; flex-wrap:wrap;">

--- a/apps/front/src/services/sveltekit-api/people.ts
+++ b/apps/front/src/services/sveltekit-api/people.ts
@@ -4,6 +4,11 @@ import type { PeopleType } from '@ajustor/simulation'
 export const callGetPeople = async (civilizationId: string, pageIndex: number, pageSize: number): Promise<{ people: PeopleType[] }> => {
   const response = await fetch(`/my-civilizations/${civilizationId}?${new URLSearchParams({ civilizationId, page: `${pageIndex}`, count: `${pageSize}` })}`, {
     method: 'GET',
+    // This route also has a +page.server.ts, so without an explicit Accept
+    // SvelteKit serves the page HTML instead of the +server.ts JSON endpoint.
+    headers: {
+      Accept: 'application/json',
+    },
   })
 
   return response.json()

--- a/apps/front/src/services/sveltekit-api/people.ts
+++ b/apps/front/src/services/sveltekit-api/people.ts
@@ -2,10 +2,8 @@ import type { PeopleType } from '@ajustor/simulation'
 
 
 export const callGetPeople = async (civilizationId: string, pageIndex: number, pageSize: number): Promise<{ people: PeopleType[] }> => {
-  const response = await fetch(`/my-civilizations/${civilizationId}?${new URLSearchParams({ civilizationId, page: `${pageIndex}`, count: `${pageSize}` })}`, {
+  const response = await fetch(`/my-civilizations/${civilizationId}/people?${new URLSearchParams({ page: `${pageIndex}`, count: `${pageSize}` })}`, {
     method: 'GET',
-    // This route also has a +page.server.ts, so without an explicit Accept
-    // SvelteKit serves the page HTML instead of the +server.ts JSON endpoint.
     headers: {
       Accept: 'application/json',
     },

--- a/packages/simulation/src/builders/peopleBuilder.ts
+++ b/packages/simulation/src/builders/peopleBuilder.ts
@@ -15,6 +15,11 @@ export class PeopleBuilder {
     return this
   }
 
+  withName(name: string): PeopleBuilder {
+    this.peopleEntity.name = name
+    return this
+  }
+
   withMonth(month: number): PeopleBuilder {
     this.peopleEntity.month = month
     return this
@@ -57,6 +62,10 @@ export class PeopleBuilder {
     const peopleBuilder = new PeopleBuilder()
       .withGender(child?.gender)
       .withLifeCounter(child.lifeCounter)
+
+    if (child.name) {
+      peopleBuilder.withName(child.name)
+    }
 
     if (child.occupation) {
       peopleBuilder.withOccupation(child.occupation)

--- a/packages/simulation/src/builders/worldBuilder.ts
+++ b/packages/simulation/src/builders/worldBuilder.ts
@@ -1,7 +1,7 @@
 import type { Civilization } from '../civilization'
 import { Events } from '../events/enum'
 import { Resource } from '../resource'
-import { World } from '../world'
+import { World, type WorldConfig } from '../world'
 
 export class WorldBuilder {
   private id: string = ''
@@ -10,6 +10,14 @@ export class WorldBuilder {
   private resources: Resource[] = [];
   private civilizations: Civilization[] = [];
   private nextEvent: Events | null = null
+  private config?: WorldConfig
+
+  withConfig(config?: Partial<WorldConfig> | null): this {
+    if (config) {
+      this.config = config as WorldConfig
+    }
+    return this
+  }
 
   withId(id: string): this {
     this.id = id
@@ -42,7 +50,7 @@ export class WorldBuilder {
   }
 
   build(): World {
-    const world = new World(this.name, this.month)
+    const world = new World(this.name, this.month, this.config)
     world.id = this.id
 
     world.nextEvent = this.nextEvent

--- a/packages/simulation/src/index.ts
+++ b/packages/simulation/src/index.ts
@@ -33,3 +33,4 @@ type CivilizationEntity = typeof Civilization
 
 export { World, Civilization, People, Resource, ResourceTypes, isExtractionBuilding }
 export type { CivilizationEntity, PeopleType, ResourceType, PeopleEntity }
+export type { WorldInfos, WorldConfig } from './world'

--- a/packages/simulation/src/people/people.ts
+++ b/packages/simulation/src/people/people.ts
@@ -11,6 +11,7 @@ import { isCollectWork, type Work } from './work/interface'
 import type { UpgradedWork } from './work/interface'
 import type { World } from '../world'
 import { isWithinChance } from '../utils'
+import { names, uniqueNamesGenerator } from 'unique-names-generator'
 import { WoodCutter } from './work/woodCutter'
 import { CharcoalBurner } from './work/charcoalBurner'
 import { Gatherer } from './work/gatherer'
@@ -59,6 +60,7 @@ export const MAX_LIFE = 12
 export const MINIMAL_AGE_TO_WORK = 4
 
 export type PeopleConstructorParams = {
+  name?: string
   month: number
   gender: Gender
   lifeCounter: number
@@ -82,6 +84,7 @@ export type Lineage = {
 }
 export class People {
   public id!: string
+  name: string
   month: number
   work: Work | UpgradedWork | null = null
   lifeCounter: number
@@ -97,6 +100,7 @@ export class People {
   tree: Tree<string> | null = null
 
   constructor({
+    name = uniqueNamesGenerator({ dictionaries: [names] }),
     month,
     gender,
     lifeCounter = 3,
@@ -106,6 +110,7 @@ export class People {
     lineage,
     numberOfChild = 0,
   }: PeopleConstructorParams) {
+    this.name = name
     this.month = month
     this.lifeCounter = lifeCounter
     this.isBuilding = isBuilding
@@ -291,6 +296,7 @@ export class People {
 
   formatToEntity(): PeopleEntity {
     return {
+      name: this.name,
       buildingMonthsLeft: this.buildingMonthsLeft,
       isBuilding: this.isBuilding,
       lifeCounter: this.lifeCounter,

--- a/packages/simulation/src/types/people.ts
+++ b/packages/simulation/src/types/people.ts
@@ -3,6 +3,7 @@ import type { Lineage } from '../people/people'
 import type { OccupationTypes } from '../people/work/enum'
 
 export interface PeopleEntity {
+  name?: string
   month: number
   occupation?: OccupationTypes
   lifeCounter: number

--- a/packages/simulation/src/world.spec.ts
+++ b/packages/simulation/src/world.spec.ts
@@ -259,7 +259,12 @@ describe('World', () => {
         worldFood.formatToType(),
         worldWood.formatToType()
       ],
-      year: 0
+      year: 0,
+      config: {
+        BASE_FOOD_GENERATION: 30000,
+        BASE_WOOD_GENERATION: 15000,
+        EVENT_CHANCE: 30
+      }
     }
 
     expect(world.getInfos()).toEqual(expectedInfos)

--- a/packages/simulation/src/world.ts
+++ b/packages/simulation/src/world.ts
@@ -21,6 +21,7 @@ export type WorldInfos = {
   year: number
   nextEvent: Events | null
   civilizations: CivilizationType[]
+  config: WorldConfig
 }
 
 export type WorldConfig = {
@@ -68,12 +69,25 @@ export class World {
   public nextEvent: Events | null = null
   public lastBattles: CombatRecord[] = []
 
+  private config: WorldConfig
+
   constructor(
     private readonly name = 'The world',
     private month = 0,
-    private config: WorldConfig = { ...defaultConfig },
+    config: Partial<WorldConfig> = {},
   ) {
     this.id = ''
+    // Merge with defaults so a partial (custom) config can override only some
+    // fields; a missing field falls back to the default rather than clobbering it.
+    this.config = {
+      BASE_FOOD_GENERATION: config.BASE_FOOD_GENERATION ?? defaultConfig.BASE_FOOD_GENERATION,
+      BASE_WOOD_GENERATION: config.BASE_WOOD_GENERATION ?? defaultConfig.BASE_WOOD_GENERATION,
+      EVENT_CHANCE: config.EVENT_CHANCE ?? defaultConfig.EVENT_CHANCE,
+    }
+  }
+
+  getConfig(): WorldConfig {
+    return this.config
   }
 
   get season(): string {
@@ -359,6 +373,7 @@ export class World {
       })),
       nextEvent: this.nextEvent,
       year: this.getYear(),
+      config: this.config,
     }
   }
 


### PR DESCRIPTION
…crite + corrections

- citoyens: réintroduction du champ `name` (simulation, schéma Mongo, mapper, colonne dans le tableau) + script de rattrapage manuel `bun run backfill:names`
- pagination: callGetPeople envoie `Accept: application/json` (la route a un +page et un +server, SvelteKit renvoyait le HTML)
- config: `dataType: 'json'` sur le superForm pour que les tableaux échanges/guerre soient bien postés
- notifications: l'autorisation privilégie le bearer explicite plutôt que le cookie (corrige le 403)
- marché: offres plus lisibles (blocs Offre / En échange + sens d'acceptation explicite)
- fil d'Ariane: composant réutilisable adopté sur civilisation, config, conflits, marché et compte
- live: SSE `GET /worlds/:id/events` + MonthWatcher, rafraîchissement de l'écran à chaque passage de mois
- typo: titres en Tangerine (calligraphie parchemin), corps EB Garamond conservé pour la lisibilité