### PR TITLE
fix(simulation): piloter la limite d'enfants par la config de la civilisation

### DIFF
--- a/packages/simulation/src/civilization.ts
+++ b/packages/simulation/src/civilization.ts
@@ -519,11 +519,13 @@ export class Civilization {
       ({ work }) => work?.occupationType !== OccupationTypes.RETIRED,
     ).length
 
-    // Allow only half people to be child
-    const adults = this.getPeopleWithoutOccupation(OccupationTypes.CHILD)
+    // The maximum number of simultaneous children is governed solely by the
+    // civilization's own configuration (MAXIMUM_CHILDREN) so that what the
+    // player sets is exactly what applies. createNewPeople enforces the same
+    // cap defensively.
     if (
       activePeopleCount < this.config.MAX_ACTIVE_PEOPLE_BY_CIVILIZATION &&
-      children.length < (adults.length * 1) / 3
+      this.childrenCount < this.config.MAXIMUM_CHILDREN
     ) {
       await this.createNewPeople()
     }


### PR DESCRIPTION
## Contexte

Signalement : « les femmes ne tombent plus enceinte depuis qu'on a mis la configuration ».

## Diagnostic

Le passage des mois fonctionne. La régression vient de la gestion de la natalité, qui était bridée par **deux** barrières dans `packages/simulation/src/civilization.ts` :

1. `passAMonth` (~ligne 524) : une règle **codée en dur, non configurable** → `children.length < adults.length / 3`
2. `createNewPeople` (~ligne 989) : le plafond de config → `MAXIMUM_CHILDREN <= childrenCount`

`MAXIMUM_CHILDREN` vaut **10 par défaut** et s'applique à **toute la civilisation**. Comme un enfant ne quitte le statut `CHILD` qu'à 12 ans, toute civilisation un peu établie atteint vite 10 enfants simultanés et **toutes les grossesses s'arrêtent**. La règle codée en dur `adults/3`, elle, n'était pas réglable par le joueur.

Le reste du circuit honore déjà la config de bout en bout (DTO → Mongo → `civilizationMapper` → simulation, et `saveAll` préserve la config).

## Correction

Conformément à la demande (« utiliser la valeur de la configuration de la civilisation en cours »), la règle codée en dur `adults/3` est remplacée par la valeur configurée `MAXIMUM_CHILDREN`. La configuration de la civilisation devient la **seule autorité** sur le nombre d'enfants simultanés ; `createNewPeople` applique le même plafond de façon défensive.

Le joueur peut donc relever `MAXIMUM_CHILDREN` dans l'écran de configuration pour débloquer/augmenter la natalité de ses grandes civilisations.

## Vérifications

- `bun build` du package `@ajustor/simulation` : OK
- Modif type-correcte ; `config` est toujours initialisé (défaut = `defaultCivilizationConfig`), pas d'accès `undefined`
- Note : la suite jest n'a pas pu tourner dans cet environnement éphémère (résolution des types/source-map cassée, indépendant de ce changement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGWe3oxTRWgVMbCXE2SJit)_