### PR TITLE
fix(live): rafraîchissement auto robuste (SSE + fallback polling)

### DIFF
--- a/apps/back/src/modules/world/index.ts
+++ b/apps/back/src/modules/world/index.ts
@@ -6,6 +6,7 @@ import { logger } from '@bogeychan/elysia-logger'
 import { WorldService } from './service'
 import { PeopleService } from '../people/service'
 import { monthWatcher } from '../../libs/services/monthWatcher'
+import { WorldModel } from '../../libs/database/models'
 
 const worldDbClientInstance = new WorldsTable()
 const peopleServiceInstance = new PeopleService()
@@ -151,7 +152,15 @@ export const worldModule = new Elysia({ prefix: '/worlds' })
     set.headers['content-type'] = 'text/event-stream'
     set.headers['cache-control'] = 'no-cache'
     set.headers['connection'] = 'keep-alive'
+    // Disable proxy buffering (nginx & co) so events are flushed immediately.
+    set.headers['x-accel-buffering'] = 'no'
     return stream
+  })
+  // Lightweight current-month endpoint, used as a polling fallback for the live
+  // refresh when SSE is blocked/buffered by a reverse proxy.
+  .get('/:worldId/month', async ({ params: { worldId } }) => {
+    const world = await WorldModel.findOne({ _id: worldId }, 'month')
+    return { month: world?.month ?? 0 }
   })
   .get('/:worldId/civilizations', async ({ civilizationsDbClient, params: { worldId } }) => {
     const civilizations = await civilizationsDbClient.getAllRawByWorldId(worldId, { people: false })

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -53,20 +53,49 @@
 		})()
 	}
 
-	// Live refresh: the world advances a month every ~15 min server-side. Subscribe
-	// to its SSE stream and refresh the on-screen data whenever a month passes.
+	// Live refresh: the world advances a month every ~15 min server-side.
 	onMount(() => {
 		if (!data.worldId) {
 			return
 		}
-		const source = new EventSource(`${PUBLIC_BACK_URL}/worlds/${data.worldId}/events`)
-		source.addEventListener('month', async () => {
+		const worldId = data.worldId
+
+		const refresh = async () => {
 			// Refresh civilization stats/resources (data is replaced -> reactive) and
 			// re-fetch the citizens page currently shown.
 			await invalidateAll()
 			retrievePeople(pageIndex, pageSize)
+		}
+
+		// Primary path: SSE push as soon as the world advances a month.
+		const source = new EventSource(`${PUBLIC_BACK_URL}/worlds/${worldId}/events`)
+		source.addEventListener('month', () => {
+			void refresh()
 		})
-		return () => source.close()
+
+		// Fallback: poll the world's month in case SSE is blocked/buffered by a
+		// reverse proxy. Cheap endpoint, only triggers a refresh on an actual change.
+		let knownMonth: number | null = null
+		const poll = setInterval(async () => {
+			try {
+				const response = await fetch(`${PUBLIC_BACK_URL}/worlds/${worldId}/month`)
+				if (!response.ok) {
+					return
+				}
+				const { month } = await response.json()
+				if (knownMonth !== null && month !== knownMonth) {
+					void refresh()
+				}
+				knownMonth = month
+			} catch (error) {
+				console.error(error)
+			}
+		}, 60_000)
+
+		return () => {
+			source.close()
+			clearInterval(poll)
+		}
 	})
 
 	const RESOURCES_INDEXES = {


### PR DESCRIPTION
Le refresh auto ne se déclenchait pas en prod (probable buffering SSE par le reverse proxy).
- SSE: ajoute l'en-tête X-Accel-Buffering:no pour forcer le flush immédiat des événements
- nouvel endpoint léger GET /worlds/:id/month
- la page civilisation interroge ce mois toutes les 60s en secours si le SSE est bloqué, et rafraîchit (invalidateAll + page citoyens) dès que le mois change

Note: la construction choisie se déroulait bien côté serveur ; elle n'était simplement pas visible faute de rafraîchissement (et démarre en "Constructions en cours" pour la durée du bâtiment, sous réserve des ressources/ouvriers disponibles).