### PR TITLE
fix(simulation): faire fonctionner la mine (mineurs + extraction)

### DIFF
--- a/packages/simulation/src/buildings/mine.spec.ts
+++ b/packages/simulation/src/buildings/mine.spec.ts
@@ -1,0 +1,70 @@
+import { Civilization } from '../civilization'
+import { People } from '../people/people'
+import { Resource, ResourceTypes } from '../resource'
+import { BuildingTypes } from './enum'
+import { Gender } from '../people/enum'
+import { OccupationTypes } from '../people/work/enum'
+import { Mine } from './mine'
+
+const buildMiner = (id: string) => {
+  const person = new People({
+    month: 12 * 30,
+    gender: Gender.MALE,
+    lifeCounter: 50,
+  })
+  person.id = id
+  person.setOccupation(OccupationTypes.MINER)
+  return person
+}
+
+describe('Mine', () => {
+  it('keeps the count passed to its constructor', () => {
+    // Regression: the Mine had no constructor, so `new Mine(1)` produced a mine
+    // with count 0. That broke worker allocation (no miners could ever be hired
+    // because the available "miner space" is count * 10) and made the building
+    // invisible to the count-gated build/UI logic.
+    expect(new Mine(1).count).toBe(1)
+    expect(new Mine(3).count).toBe(3)
+  })
+
+  it('generates at least one extractable resource with a non-zero probability', () => {
+    const mine = new Mine(1)
+    mine.generateOutput([ResourceTypes.STONE])
+
+    expect(mine.outputResources).toHaveLength(1)
+    expect(mine.outputResources[0]?.resource).toBe(ResourceTypes.STONE)
+    expect(mine.outputResources[0]?.probability).toBeGreaterThan(0)
+  })
+
+  it('lets miners extract resources and depletes the capacity', () => {
+    const civ = new Civilization('Diggers')
+    const mine = new Mine(1)
+    mine.capacity = 50
+    mine.outputResources = [{ resource: ResourceTypes.STONE, probability: 100 }]
+    civ.addBuilding(mine)
+
+    for (let i = 0; i < 10; i++) {
+      civ.addPeople(buildMiner(`miner-${i}`))
+    }
+
+    civ['extractResources']()
+
+    // Several miners extracted stone in a single month and the capacity dropped.
+    expect(civ.getResource(ResourceTypes.STONE).quantity).toBeGreaterThan(0)
+  })
+
+  it('disappears once its capacity is exhausted so a new one can be built', () => {
+    const civ = new Civilization('Diggers')
+    const mine = new Mine(1)
+    mine.capacity = 1
+    mine.outputResources = [{ resource: ResourceTypes.STONE, probability: 100 }]
+    civ.addBuilding(mine)
+    civ.addPeople(buildMiner('miner-0'))
+
+    civ['extractResources']()
+
+    expect(
+      civ.buildings.some((b) => b.getType() === BuildingTypes.MINE),
+    ).toBe(false)
+  })
+})

--- a/packages/simulation/src/buildings/mine.ts
+++ b/packages/simulation/src/buildings/mine.ts
@@ -11,6 +11,9 @@ import { getRandomInt } from '../utils/random'
 import { BuildingTypes } from './enum'
 
 export class Mine extends AbstractExtractionBuilding {
+  constructor(public count = 0) {
+    super()
+  }
   workerTypeRequired: WorkerRequired[] = [
     { occupation: OccupationTypes.MINER, count: 10 },
   ]
@@ -40,11 +43,14 @@ export class Mine extends AbstractExtractionBuilding {
   public generateOutput(possibleOutput: ResourceTypes[]) {
     let percent = 0
     for (const resource of possibleOutput) {
-      if (percent === 100) {
+      if (percent >= 100) {
         return
       }
 
-      const currentPercent = getRandomInt(0, 100 - percent)
+      // Each resource gets at least a 1% extraction chance so a freshly built
+      // mine is never inert (which would let it produce nothing and never
+      // deplete, so it could never be replaced).
+      const currentPercent = getRandomInt(1, 100 - percent)
       percent += currentPercent
 
       this.outputResources.push({ resource, probability: currentPercent })

--- a/packages/simulation/src/civilization.ts
+++ b/packages/simulation/src/civilization.ts
@@ -18,7 +18,7 @@ import { Resource, ResourceTypes } from "./resource";
 import { OCCUPATION_TREE } from "./technology/occupationTree";
 import {
   AbstractExtractionBuilding, AbstractStorageBuilding, Building, ConstructionCost,
-  ExtractionBuilding, ProductionBuilding, type, type, type, type, WorkerRequiredToBuild
+  ExtractionBuilding, ProductionBuilding, WorkerRequiredToBuild
 } from "./types/building";
 import { isWithinChance } from "./utils";
 import { hasElementInCommon } from "./utils/array";
@@ -622,25 +622,34 @@ export class Civilization {
     }
 
     for (const requiredWorker of requiredWorkers) {
-      const worker = this.getPeopleWithOccupation(
+      // The building employs up to `count` workers per unit built. Each working
+      // miner gets an independent extraction roll, so output scales with the
+      // size of the available workforce instead of a single token worker.
+      const maxWorkers = requiredWorker.count * Math.max(building.count, 1);
+      const availableWorkers = this.getPeopleWithOccupation(
         requiredWorker.occupation,
-      ).find((people) => people.canWork());
+      )
+        .filter((people) => people.canWork())
+        .slice(0, maxWorkers);
 
-      if (!worker) {
-        return;
+      if (!availableWorkers.length) {
+        continue;
       }
-      worker.hasWork = true;
-      for (const resource of resourcesProbabilities) {
-        if (isWithinChance(resource.probability)) {
-          const amount = getRandomInt(1, 100);
-          this.increaseResource(resource.resource, amount);
 
-          if (building.capacity != null) {
-            building.capacity -= amount;
+      for (const worker of availableWorkers) {
+        worker.hasWork = true;
+        for (const resource of resourcesProbabilities) {
+          if (isWithinChance(resource.probability)) {
+            const amount = getRandomInt(1, 100);
+            this.increaseResource(resource.resource, amount);
 
-            if (building.capacity <= 0) {
-              this.removeBuilding(building);
-              return;
+            if (building.capacity != null) {
+              building.capacity -= amount;
+
+              if (building.capacity <= 0) {
+                this.removeBuilding(building);
+                return;
+              }
             }
           }
         }


### PR DESCRIPTION
## Problème

La mine ne fonctionnait pas du tout. Cause racine : la classe `Mine` n'avait **aucun constructeur**, contrairement à tous les autres bâtiments. Or les deux chemins qui créent une mine passent un `count` :

- `new Mine(building.count)` au rechargement depuis la DB (`service.ts`)
- `new Mine(1)` à la construction (`constructBuilding`)

Sans constructeur, cet argument est ignoré et `count` reste à **0**.

### Conséquences d'un `count = 0`
- `getWorkerSpaceLeft(MINER)` vaut `count × 10 = 0` → **aucun gatherer ne devient jamais mineur**, la mine n'a pas de main-d'œuvre.
- La logique de build/affichage gâchée par `count` (`this.mine?.count` falsy) considère la mine comme inexistante et reconstruit en boucle.
- Chaque rechargement mensuel depuis la DB remet `count` à 0.

## Corrections

- **`Mine` reçoit un constructeur `count`**, comme tous les autres bâtiments. (cause racine)
- **L'extraction emploie jusqu'à `count` mineurs** par unité construite dans `extractResourcesFromBuilding` (au lieu d'un seul mineur symbolique), donc la production suit la taille de la main-d'œuvre — les « divers ratios » attendus.
- **`generateOutput` garantit une probabilité d'extraction non nulle** : une mine fraîche n'est jamais inerte (sinon elle ne produirait rien et ne s'épuiserait jamais, donc ne pourrait jamais être remplacée).
- **Réparation d'un import `./types/building` cassé** (`type, type, type, type`) qui rendait le package non compilable.

## Tests

- Ajout de `mine.spec.ts` : persistance du `count`, génération d'output, extraction par plusieurs mineurs, et disparition de la mine une fois la capacité épuisée.
- `tsc --noEmit` passe ; aucune régression sur la suite (13 échecs préexistants identiques avant/après, sans rapport avec la mine — voir note).

## Note (hors périmètre)

En réparant l'import, j'ai démasqué des tests préexistants qui ne tournaient plus (la branche ne compilait pas) :
- `civilization.spec.ts` : 12 tests désynchronisés du refactor (upgrades, coûts, alimentation, chauffage charbon/bois).
- `chosen-building.spec.ts` : le test « build another Cache » n'ajoute pas les 200 WOOD requis par `Cache.constructionCosts`.

Je les ai laissés tels quels car sans rapport avec la mine. À traiter séparément si souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECU1M21DaUaK8SjWo21kNo)_