### PR TITLE
Recap threshold, resource chart fix, live refresh & market stock info

### DIFF
--- a/apps/back/src/modules/civilizations/recap.ts
+++ b/apps/back/src/modules/civilizations/recap.ts
@@ -1,5 +1,10 @@
 import type { BuildingTypes, Events, ResourceTypes } from '@ajustor/simulation'
 
+// Nombre minimum de mois écoulés depuis la dernière visite pour afficher le
+// récap "pendant ton absence". En dessous (un seul mois), l'absence est trop
+// courte pour mériter une notification.
+export const RECAP_MIN_MONTHS = 2
+
 export type RecapStatsSnapshot = {
   month: number
   people?: { men: number; women: number; pregnantWomen: number } | null

--- a/apps/back/src/modules/civilizations/service.ts
+++ b/apps/back/src/modules/civilizations/service.ts
@@ -21,7 +21,7 @@ import {
   UserModel,
   WorldModel,
 } from '../../libs/database/models'
-import { computeRecap, emptyRecap, type RecapData, type RecapStatsSnapshot, type RecapCombatLog } from './recap'
+import { computeRecap, emptyRecap, RECAP_MIN_MONTHS, type RecapData, type RecapStatsSnapshot, type RecapCombatLog } from './recap'
 import { PeopleService, personMapper } from '../people/service'
 import { UpdateCivilizationDtoType } from './dto'
 import { AnyBulkWriteOperation } from 'mongoose'
@@ -723,6 +723,12 @@ export class CivilizationService {
       return emptyRecap()
     }
     if (toMonth <= fromMonth) {
+      return emptyRecap()
+    }
+    // Absence trop courte (un seul mois écoulé) : pas de récap. On n'avance pas
+    // la référence pour laisser la période s'accumuler jusqu'à la prochaine
+    // visite, afin de ne pas perdre ce mois si une vraie absence suit.
+    if (toMonth - fromMonth < RECAP_MIN_MONTHS) {
       return emptyRecap()
     }
 

--- a/apps/front/src/lib/components/charts/Bar.svelte
+++ b/apps/front/src/lib/components/charts/Bar.svelte
@@ -20,7 +20,6 @@
 		LineElement,
 		BarElement
 	} from 'chart.js'
-	import { onMount } from 'svelte'
 
 	interface Props {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,8 +46,11 @@
 
 	let chart: HTMLCanvasElement = $state()
 
-	onMount(() => {
-		new ChartJS(chart, {
+	// Rebuild the chart whenever `data`/`options` change. The previous version only
+	// drew once in onMount, so the live auto-refresh (and any reactive data update)
+	// never reached the canvas. Destroying the prior instance avoids leaking charts.
+	$effect(() => {
+		const instance = new ChartJS(chart, {
 			type: 'bar',
 			data,
 			options: {
@@ -56,6 +58,7 @@
 				...options
 			}
 		})
+		return () => instance.destroy()
 	})
 </script>
 

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -15,6 +15,7 @@
 	import PeopleTable from './datatables/people-table.svelte'
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 	import { callGetPeople } from '../../../services/sveltekit-api/people'
+	import { callGetStats } from '../../../services/sveltekit-api/civilization'
 	import { onMount } from 'svelte'
 	import { invalidateAll } from '$app/navigation'
 	import { PUBLIC_BACK_URL } from '$env/static/public'
@@ -34,6 +35,22 @@
 	// prop's nested promise is NOT reactive in Svelte 5, so the table never updated.
 	let peoplePromise = $state<Promise<PeopleType[]>>(data.lazy.people)
 	let recap = $state<RecapData | null>(null)
+
+	// Same reasoning as `peoplePromise`: the server-streamed stat promises captured
+	// here are not reactive, so the charts/combat-log never refreshed live. We hold
+	// them in local state and re-fetch via the client `/stats` endpoint on refresh.
+	let statsPromise = $state(data.lazy.stats.civilization)
+	let jobsPromise = $state(data.lazy.stats.jobs)
+	let peopleRatioPromise = $state(data.lazy.stats.peopleRatio)
+	let combatLogsPromise = $state(data.lazy.combatLogs)
+
+	const refreshStats = () => {
+		const stats = callGetStats(data.civilization.id)
+		statsPromise = stats.then((s) => s.civilization)
+		jobsPromise = stats.then((s) => s.jobs)
+		peopleRatioPromise = stats.then((s) => s.peopleRatio)
+		combatLogsPromise = stats.then((s) => s.combatLogs)
+	}
 
 	// Which panel is expanded: null = closed
 	type Panel = 'resources' | 'population' | 'jobs' | 'gender' | null
@@ -76,10 +93,12 @@
 		const worldId = data.worldId
 
 		const refresh = async () => {
-			// Refresh civilization stats/resources (data is replaced -> reactive) and
-			// re-fetch the citizens page currently shown.
+			// Refresh top-level civilization data (current resources, building/people
+			// counts) via invalidation, re-fetch the citizens page currently shown, and
+			// pull fresh chart/combat-log stats into local state.
 			await invalidateAll()
 			retrievePeople(pageIndex, pageSize)
+			refreshStats()
 		}
 
 		// Primary path: SSE push as soon as the world advances a month.
@@ -121,6 +140,30 @@
 		[ResourceTypes.PLANK]: 4,
 		[ResourceTypes.CHARCOAL]: 5
 	}
+
+	// Build dense, label-aligned line datasets for the resource charts.
+	// Indexing a sparse array by RESOURCES_INDEXES used to leave holes (undefined
+	// slots) whenever a resource type was absent — e.g. a civ that has charcoal but
+	// no planks. Chart.js chokes on those holes and the chart silently fails to
+	// render (which then breaks the zoom panel). Here we emit exactly one dataset
+	// per resource type that ever appears, with one value per tracked month (0 when
+	// missing) so every series stays aligned with the month labels.
+	const buildResourceDatasets = (
+		stats: { resources: { resourceType?: ResourceTypes; quantity?: number }[] }[]
+	) =>
+		(Object.entries(RESOURCES_INDEXES) as [ResourceTypes, number][])
+			.sort(([, a], [, b]) => a - b)
+			.map(([resourceType]) => resourceType)
+			.filter((resourceType) =>
+				stats.some(({ resources }) => resources.some((r) => r?.resourceType === resourceType))
+			)
+			.map((resourceType) => ({
+				type: 'line' as const,
+				label: resourceNames[resourceType],
+				data: stats.map(
+					({ resources }) => resources.find((r) => r?.resourceType === resourceType)?.quantity ?? 0
+				)
+			}))
 
 	const jobColors = [
 		'oklch(0.52 0.1 130)', 'oklch(0.55 0.1 110)', 'oklch(0.6 0.04 60)',
@@ -243,23 +286,14 @@
 
 				<!-- ── RESOURCES panel ──────────────────────────────────────── -->
 				{#if activePanel === 'resources'}
-					{#await data.lazy.stats.civilization}
+					{#await statsPromise}
 						<div style="height:200px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 					{:then civilizationStats}
 						{@const last = civilizationStats[civilizationStats.length - 1]}
 						{@const prev = civilizationStats[civilizationStats.length - 2]}
 						{@const events = civilizationStats.filter(s => s.event)}
 						{@const labels = civilizationStats.map(({ month, event }) => `M${month}${event ? ` (${eventsName[event as Events]})` : ''}`)}
-						{@const datasets = civilizationStats.reduce<{ data: number[]; label: string; type: string }[]>(
-							(acc, { resources }) => {
-								for (const r of resources) {
-									if (!r?.resourceType) continue
-									acc[RESOURCES_INDEXES[r.resourceType as ResourceTypes]] ??= { data: [], label: resourceNames[r.resourceType as ResourceTypes], type: 'line' }
-									acc[RESOURCES_INDEXES[r.resourceType as ResourceTypes]].data.push(r.quantity ?? 0)
-								}
-								return acc
-							}, []
-						)}
+						{@const datasets = buildResourceDatasets(civilizationStats)}
 						<div style="display:grid; grid-template-columns:260px 1fr; gap:20px;">
 							<!-- Stats panel -->
 							<div style="background:oklch(0.91 0.025 78); border:1px solid oklch(0.78 0.045 70); border-radius:4px; padding:16px 18px; display:flex; flex-direction:column; gap:12px;">
@@ -317,7 +351,7 @@
 
 				<!-- ── POPULATION panel ──────────────────────────────────────── -->
 				{:else if activePanel === 'population'}
-					{#await data.lazy.stats.civilization}
+					{#await statsPromise}
 						<div style="height:200px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 					{:then civilizationStats}
 						{@const last = civilizationStats[civilizationStats.length - 1]}
@@ -391,7 +425,7 @@
 
 				<!-- ── JOBS panel ──────────────────────────────────────────────── -->
 				{:else if activePanel === 'jobs'}
-					{#await data.lazy.stats.jobs}
+					{#await jobsPromise}
 						<div style="height:200px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 					{:then jobs}
 						{@const entries = Object.entries(jobs).filter(([k]) => k !== 'child').sort(([,a],[,b]) => (b as number)-(a as number))}
@@ -417,7 +451,7 @@
 
 				<!-- ── GENDER panel ─────────────────────────────────────────────── -->
 				{:else if activePanel === 'gender'}
-					{#await data.lazy.stats.peopleRatio}
+					{#await peopleRatioPromise}
 						<div style="height:200px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 					{:then peopleRatio}
 						{#if peopleRatio}
@@ -513,7 +547,7 @@
 
 		<!-- Charts row -->
 		<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:20px; margin-top:24px;">
-			{#await data.lazy.stats.civilization}
+			{#await statsPromise}
 				<div style="height:180px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 				<div style="height:180px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 			{:then civilizationStats}
@@ -536,18 +570,7 @@
 							<Line
 								data={{
 									labels,
-									datasets: resources.reduce<{ data: number[]; label: string; type: string }[]>(
-										(datasets, civResources) => {
-											for (const resource of civResources) {
-												if (!resource?.resourceType) continue
-												datasets[RESOURCES_INDEXES[resource.resourceType as ResourceTypes]] ??= {
-													data: [], label: resourceNames[resource.resourceType as ResourceTypes], type: 'line'
-												}
-												datasets[RESOURCES_INDEXES[resource.resourceType as ResourceTypes]].data.push(resource.quantity ?? 0)
-											}
-											return datasets
-										}, []
-									)
+									datasets: buildResourceDatasets(civilizationStats)
 								}}
 							/>
 						{/await}
@@ -590,7 +613,7 @@
 
 		<!-- Jobs + Gender row -->
 		<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:20px; margin-top:20px;">
-			{#await data.lazy.stats.jobs}
+			{#await jobsPromise}
 				<div style="height:200px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 			{:then jobs}
 				{@const activeEntries = Object.entries(jobs).filter(([k]) => k !== 'child')}
@@ -622,7 +645,7 @@
 				</button>
 			{/await}
 
-			{#await data.lazy.stats.peopleRatio}
+			{#await peopleRatioPromise}
 				<div style="height:200px; border-radius:4px; background:oklch(0.9 0.02 80); animation:civPulse 1.5s ease infinite;"></div>
 			{:then peopleRatio}
 				{#if peopleRatio}
@@ -752,7 +775,7 @@
 				<a href="/my-civilizations/{data.civilization.id}/combats" style="font-size:15px; color:oklch(0.5 0.13 34); font-family:'EB Garamond',serif; text-decoration:none;">Voir tous les combats →</a>
 			</div>
 
-			{#await data.lazy.combatLogs}
+			{#await combatLogsPromise}
 				<p style="color:oklch(0.55 0.03 50); font-size:15px;">Chargement…</p>
 			{:then logs}
 				{#if !logs || logs.length === 0}

--- a/apps/front/src/routes/my-civilizations/[slug]/stats/+server.ts
+++ b/apps/front/src/routes/my-civilizations/[slug]/stats/+server.ts
@@ -1,0 +1,27 @@
+import { json } from '@sveltejs/kit'
+import {
+  getCivilizationStats,
+  getCombatLogs,
+} from '../../../../services/api/civilization-api.js'
+import {
+  getCivilizationPeopleJobsStats,
+  getCivilizationPeopleRatioStats,
+} from '../../../../services/api/people-api.js'
+
+export const prerender = false
+
+// Client-refreshable snapshot of every lazily-loaded stat the page shows. The
+// server `load` only runs on navigation/invalidation, and its streamed promises
+// captured into local component state do not update on auto-refresh — so the
+// charts and combat log are re-fetched through this endpoint instead.
+export async function GET({ cookies, params }) {
+  const auth = cookies.get('auth') ?? ''
+  const [civilization, jobs, peopleRatio, combatLogs] = await Promise.all([
+    getCivilizationStats(auth, params.slug),
+    getCivilizationPeopleJobsStats(auth, params.slug),
+    getCivilizationPeopleRatioStats(auth, params.slug),
+    getCombatLogs(auth, params.slug, 5, 0),
+  ])
+
+  return json({ civilization, jobs, peopleRatio, combatLogs }, { status: 200 })
+}

--- a/apps/front/src/routes/worlds/[worldId]/market/+page.svelte
+++ b/apps/front/src/routes/worlds/[worldId]/market/+page.svelte
@@ -16,15 +16,34 @@
 		status: string
 	}
 
+	type CivResource = { type: string; quantity: number }
 	type WorldCiv = { id: string; name: string }
+	type MyCiv = WorldCiv & { resources?: CivResource[] }
 
 	const resourceTypeValues = Object.values(ResourceTypes)
+	const myCivs = $derived(data.myCivilizations as MyCiv[])
 	const civNameMap = $derived(
 		new Map((data.worldCivilizations as WorldCiv[]).map((c) => [c.id, c.name]))
 	)
 	const myCivIds = $derived(
-		new Set((data.myCivilizations as WorldCiv[]).map((c) => c.id))
+		new Set(myCivs.map((c) => c.id))
 	)
+
+	const fmt = (n: number) => Math.round(n).toLocaleString('fr-FR')
+
+	// Current stock of the civilization selected in the "create offer" form, so a
+	// player can see how much they actually hold before proposing to give it away.
+	let selectedCivId = $state('')
+	$effect(() => {
+		if ((!selectedCivId || !myCivIds.has(selectedCivId)) && myCivs.length) {
+			selectedCivId = myCivs[0].id
+		}
+	})
+	const selectedCiv = $derived(myCivs.find((c) => c.id === selectedCivId))
+	const stockMap = $derived(
+		new Map((selectedCiv?.resources ?? []).map((r) => [r.type, r.quantity]))
+	)
+	const stockOf = (resourceType: string) => stockMap.get(resourceType) ?? 0
 
 	function civName(id: string): string {
 		return civNameMap.get(id) ?? id
@@ -81,27 +100,47 @@
 
 					<div style="display:flex; flex-direction:column; gap:6px;">
 						<label for="create-civ" style="font-size:15px; color:oklch(0.42 0.04 45);">Votre civilisation</label>
-						<select id="create-civ" name="civilizationId" class="select select-bordered w-full">
-							{#each data.myCivilizations as civ}
-								<option value={(civ as WorldCiv).id}>{(civ as WorldCiv).name}</option>
+						<select id="create-civ" name="civilizationId" bind:value={selectedCivId} class="select select-bordered w-full">
+							{#each myCivs as civ}
+								<option value={civ.id}>{civ.name}</option>
 							{/each}
 						</select>
+					</div>
+
+					<!-- Stock courant de la civilisation sélectionnée -->
+					<div style="border:1px solid oklch(0.78 0.045 70); border-radius:4px; padding:10px 14px; background:oklch(0.96 0.02 84);">
+						<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.5 0.05 50); margin-bottom:6px;">Stock courant</div>
+						<div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:4px 16px;">
+							{#each resourceTypeValues as rt}
+								<div style="display:flex; justify-content:space-between; font-size:14px;">
+									<span style="color:oklch(0.45 0.04 48);">{resourceNames[rt]}</span>
+									<span style="color:oklch(0.3 0.04 40); font-weight:600;">{fmt(stockOf(rt))}</span>
+								</div>
+							{/each}
+						</div>
 					</div>
 
 					<!-- Vous donnez -->
 					<div style="display:flex; flex-direction:column; gap:8px;">
 						<p style="font-family:'Marcellus',serif; font-size:17px; color:oklch(0.38 0.04 40); margin:0;">Vous donnez</p>
 						{#each giveLines as line, i}
-							<div style="display:flex; gap:8px; align-items:center;">
-								<select name="giveResource" bind:value={line.resource} class="select select-bordered" style="flex:1;">
-									{#each resourceTypeValues as rt}
-										<option value={rt}>{resourceNames[rt]}</option>
-									{/each}
-								</select>
-								<input type="number" name="giveQuantity" bind:value={line.quantity} min="1" class="input input-bordered" style="width:80px;" />
-								{#if giveLines.length > 1}
-									<button type="button" onclick={() => removeLine(giveLines, i)} style="padding:6px 10px; border:1px solid oklch(0.52 0.2 30); border-radius:4px; background:none; color:oklch(0.52 0.2 30); cursor:pointer;">×</button>
-								{/if}
+							{@const stock = stockOf(line.resource)}
+							{@const exceeds = line.quantity > stock}
+							<div style="display:flex; flex-direction:column; gap:2px;">
+								<div style="display:flex; gap:8px; align-items:center;">
+									<select name="giveResource" bind:value={line.resource} class="select select-bordered" style="flex:1;">
+										{#each resourceTypeValues as rt}
+											<option value={rt}>{resourceNames[rt]} (stock : {fmt(stockOf(rt))})</option>
+										{/each}
+									</select>
+									<input type="number" name="giveQuantity" bind:value={line.quantity} min="1" class="input input-bordered" style="width:80px;" />
+									{#if giveLines.length > 1}
+										<button type="button" onclick={() => removeLine(giveLines, i)} style="padding:6px 10px; border:1px solid oklch(0.52 0.2 30); border-radius:4px; background:none; color:oklch(0.52 0.2 30); cursor:pointer;">×</button>
+									{/if}
+								</div>
+								<span style="font-size:13px; color:{exceeds ? 'oklch(0.52 0.2 30)' : 'oklch(0.5 0.03 50)'};">
+									Stock disponible : {fmt(stock)}{#if exceeds} — quantité supérieure au stock{/if}
+								</span>
 							</div>
 						{/each}
 						{#if giveLines.length < resourceTypeValues.length}

--- a/apps/front/src/routes/worlds/[worldId]/market/+page.svelte
+++ b/apps/front/src/routes/worlds/[worldId]/market/+page.svelte
@@ -45,6 +45,15 @@
 	)
 	const stockOf = (resourceType: string) => stockMap.get(resourceType) ?? 0
 
+	// Quick-select helpers: set a give line's quantity to a fraction of the current
+	// stock of its resource (rounded down, at least 1 if any stock is held).
+	const stockFractions = [0.1, 0.5, 1] as const
+	function setGiveFromStock(line: { resource: string; quantity: number }, fraction: number) {
+		const stock = stockOf(line.resource)
+		if (stock <= 0) return
+		line.quantity = Math.max(1, Math.floor(stock * fraction))
+	}
+
 	function civName(id: string): string {
 		return civNameMap.get(id) ?? id
 	}
@@ -138,9 +147,22 @@
 										<button type="button" onclick={() => removeLine(giveLines, i)} style="padding:6px 10px; border:1px solid oklch(0.52 0.2 30); border-radius:4px; background:none; color:oklch(0.52 0.2 30); cursor:pointer;">×</button>
 									{/if}
 								</div>
-								<span style="font-size:13px; color:{exceeds ? 'oklch(0.52 0.2 30)' : 'oklch(0.5 0.03 50)'};">
-									Stock disponible : {fmt(stock)}{#if exceeds} — quantité supérieure au stock{/if}
-								</span>
+								<div style="display:flex; flex-wrap:wrap; align-items:center; gap:8px;">
+									<span style="font-size:13px; color:{exceeds ? 'oklch(0.52 0.2 30)' : 'oklch(0.5 0.03 50)'};">
+										Stock disponible : {fmt(stock)}{#if exceeds} — quantité supérieure au stock{/if}
+									</span>
+									{#if stock > 0}
+										<div style="display:flex; gap:4px;">
+											{#each stockFractions as fraction}
+												<button
+													type="button"
+													onclick={() => setGiveFromStock(line, fraction)}
+													style="padding:2px 8px; border:1px solid oklch(0.74 0.05 60); border-radius:4px; background:none; color:oklch(0.45 0.06 40); font-family:'EB Garamond',serif; font-size:13px; cursor:pointer;"
+												>{Math.round(fraction * 100)}%</button>
+											{/each}
+										</div>
+									{/if}
+								</div>
 							</div>
 						{/each}
 						{#if giveLines.length < resourceTypeValues.length}

--- a/apps/front/src/services/sveltekit-api/civilization.ts
+++ b/apps/front/src/services/sveltekit-api/civilization.ts
@@ -11,3 +11,16 @@ export const callGetCivilizations = async () => {
 
   return response.json()
 }
+
+// Fresh snapshot of the lazily-loaded stats (charts + combat logs), used by the
+// live auto-refresh since the server-streamed promises don't update on their own.
+export const callGetStats = async (civilizationId: string) => {
+  const response = await fetch(`/my-civilizations/${civilizationId}/stats`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+
+  return response.json()
+}


### PR DESCRIPTION
## Résumé

Quatre améliorations sur l'affichage des civilisations et le marché.

### 1. Notif de retour — seuil d'un mois
La modale « Pendant ton absence » ne s'affiche plus quand un seul mois s'est écoulé depuis la dernière visite. La période n'est pas perdue : on n'avance pas `lastSeenMonth` tant que le seuil (`RECAP_MIN_MONTHS = 2`) n'est pas atteint, donc le récap s'accumule jusqu'à la prochaine vraie absence.
- `apps/back/src/modules/civilizations/recap.ts`, `service.ts`

### 2. Graphe des ressources qui ne s'affichait pas / cassait le zoom
Les datasets étaient construits dans un tableau **creux** indexé par type de ressource. Dès qu'un type était absent (ex. une civ avec du charbon mais pas de planches), un trou `undefined` faisait planter Chart.js → le graphe ne s'affichait pas et le zoom était cassé. Remplacé par un helper produisant des **datasets denses et alignés** sur les labels (une valeur par mois, 0 si absente).
- `apps/front/.../[slug]/+page.svelte`

### 3. Auto-refresh des graphes
- `Bar.svelte` ne dessinait qu'au `onMount` → aucune mise à jour live. Passé en `$effect` (redessine + détruit l'instance précédente).
- Les promesses de stats streamées par le `load` serveur ne sont pas réactives à l'auto-refresh. Elles sont désormais pilotées par un état local re-fetché via un nouvel endpoint `/my-civilizations/[slug]/stats` (même pattern que `peoplePromise`).

### 4. Stock courant dans la proposition au marché
Le formulaire d'offre affiche maintenant le **stock courant** de la civilisation sélectionnée : récapitulatif de toutes les ressources + stock disponible par ligne « Vous donnez », avec une alerte si la quantité dépasse le stock.
- `apps/front/.../worlds/[worldId]/market/+page.svelte`

## Tests
- `bun test recap.test.ts` : 7 pass.
- `svelte-check` : 132 erreurs (toutes préexistantes — baseline 136 ; ces changements en retirent 4 et n'en ajoutent aucune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ur9pzaaPu4wwkSwzQiTrw)_