### PR TITLE
Fix skipYears: replay the production monthly tick

### DIFF
--- a/apps/back/skipYears.ts
+++ b/apps/back/skipYears.ts
@@ -3,7 +3,8 @@ import { WorldsTable } from './src/modules/world/database'
 import { parseArgs } from "util"
 import './src/libs/database'
 import { PeopleService } from './src/modules/people/service'
-import { attachAliveCivilizations } from './src/modules/world/monthRunner'
+import { runMonthForWorld } from './src/modules/world/monthRunner'
+import mongoose from 'mongoose'
 
 const { values } = parseArgs({
   args: Bun.argv,
@@ -32,24 +33,22 @@ const monthsToPass = +values.years * 12
 
 const worlds = await worldDbClient.getAll()
 for (const world of worlds) {
-  // Attach civilizations once, then simulate every month on the same instances.
-  const worldCivilizations = await attachAliveCivilizations(
-    world,
-    civilizationsDbClient,
-  )
-
+  // Replay the exact production monthly tick for each month: reload the alive
+  // civilizations, simulate one month, then persist their stats and state.
+  // Doing it month by month (instead of simulating many months on stale, never
+  // reloaded instances) keeps the outcome identical to the regular cron, which
+  // is what keeps the civilizations alive.
   for (let i = 0; i < monthsToPass; i++) {
-    console.timeLog('skipYears', `Passing a month ${i}/${monthsToPass - 1}`)
-    await world.passAMonth()
+    console.timeLog('skipYears', `Passing a month ${i + 1}/${monthsToPass}`)
+    await runMonthForWorld(world, civilizationsDbClient)
   }
-
-  await civilizationsDbClient.saveAll(worldCivilizations)
 }
 
 console.timeLog('skipYears', 'Civilizations saved, save the worlds')
 try {
   await worldDbClient.saveAll(worlds)
   console.timeEnd('skipYears')
+  await mongoose.disconnect()
   process.exit(0)
 } catch (error) {
   console.error(error)

--- a/apps/back/src/modules/world/monthRunner.ts
+++ b/apps/back/src/modules/world/monthRunner.ts
@@ -15,6 +15,10 @@ export async function attachAliveCivilizations(
     people: true,
   })
 
+  // Reset first so a reused world instance (e.g. running several months in a
+  // row) gets the freshly reloaded civilizations instead of accumulating
+  // duplicates of the same civilization.
+  world.clearCivilizations()
   world.addCivilization(
     ...civilizations.filter((civilization) => civilization.people.length),
   )

--- a/packages/simulation/src/world.ts
+++ b/packages/simulation/src/world.ts
@@ -106,6 +106,14 @@ export class World {
     this._civilizations.push(...civilizations)
   }
 
+  // Detach all civilizations from the world. Used when the same world instance
+  // is reused across several simulated months (e.g. the skipYears script) so
+  // freshly reloaded civilizations replace the previous ones instead of piling
+  // up as duplicates.
+  public clearCivilizations() {
+    this._civilizations = []
+  }
+
   public getYear(): number {
     return ~~(this.month / 12)
   }


### PR DESCRIPTION
## Problème

Lancer `skipYears` faisait **mourir toutes les civilisations**.

## Cause

Le script attachait les civilisations **une seule fois**, puis simulait tous les mois sur ces instances jamais rechargées :

```ts
const worldCivilizations = await attachAliveCivilizations(world, civService)
for (let i = 0; i < monthsToPass; i++) {
  await world.passAMonth()
}
await civService.saveAll(worldCivilizations)
```

Ça diverge du tick mensuel de production (`cron/passAMonth` → `runMonthForWorld`), qui **recharge les civs vivantes, enregistre leurs stats et les sauvegarde à chaque mois**. C'est ce chemin de production, rejoué toutes les ~15 min, qui maintient les civilisations en vie. La simulation continue sur des instances figées finissait par toutes les tuer.

Note : j'ai vérifié en isolation qu'une simulation mono-passe (`passAMonth` en boucle) ne tue **pas** une civ — le problème vient bien de la divergence avec le chemin de production, pas de `passAMonth` lui-même.

## Correctif

`skipYears` rejoue désormais exactement le tick de production, mois par mois :

```ts
for (let i = 0; i < monthsToPass; i++) {
  await runMonthForWorld(world, civService)
}
```

Pour que ce soit sûr quand la **même** instance de `world` est réutilisée sur plusieurs mois, `attachAliveCivilizations` réinitialise d'abord la liste des civilisations du monde (nouvelle méthode `World.clearCivilizations`) avant de rattacher les civs fraîchement rechargées — sinon `addCivilization` les empilait en doublons à chaque mois. Pour un monde neuf (le cron), ce reset est un no-op.

## Fichiers
- `apps/back/skipYears.ts` — boucle sur `runMonthForWorld`, déconnexion mongoose propre.
- `apps/back/src/modules/world/monthRunner.ts` — reset des civs avant rattachement.
- `packages/simulation/src/world.ts` — `clearCivilizations()`.

## Tests
- `world.spec.ts` : 30/30 ✅.
- Suite simulation : 138 pass / 20 fail — les 20 échecs préexistent à l'identique sur `master` (sans rapport avec ce changement).
- `tsc --noEmit` : aucune erreur de type sur les fichiers modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ur9pzaaPu4wwkSwzQiTrw)_