### PR TITLE
feat(civilizations): récupérer les ressources d'une civilisation abandonnée

### DIFF
--- a/apps/back/src/modules/civilizations/index.ts
+++ b/apps/back/src/modules/civilizations/index.ts
@@ -18,6 +18,7 @@ import { jwtMiddleware } from '../../libs/jwt'
 import { logger } from '@bogeychan/elysia-logger'
 import { UpdateCivilizationDto } from './dto'
 import { ColonizeDto } from './colonize.dto'
+import { ReclaimDto } from './reclaim.dto'
 
 const INITIAL_CITIZEN_NUMBER = 50
 const INITIAL_CITIZEN_AGE = 12 * 16
@@ -107,6 +108,22 @@ export const civilizationModule = new Elysia({ prefix: '/civilizations' })
       }
     },
     { body: ColonizeDto },
+  )
+  .post(
+    '/:civilizationId/reclaim',
+    async ({ user, civilizationService, params: { civilizationId }, body, set }) => {
+      try {
+        return await civilizationService.reclaimResources(
+          user.id as string,
+          civilizationId,
+          body.targetCivilizationId,
+        )
+      } catch (error) {
+        set.status = 400
+        return { error: error instanceof Error ? error.message : 'Unable to reclaim resources' }
+      }
+    },
+    { body: ReclaimDto },
   )
   .post(
     '',

--- a/apps/back/src/modules/civilizations/reclaim.dto.ts
+++ b/apps/back/src/modules/civilizations/reclaim.dto.ts
@@ -1,0 +1,10 @@
+import { t } from 'elysia'
+
+export const ReclaimDto = t.Object({
+  // Identifiant de la civilisation abandonnée (sans habitant) dont on récupère
+  // les ressources. Elle doit, comme la civilisation réceptrice, appartenir au
+  // joueur.
+  targetCivilizationId: t.String(),
+})
+
+export type ReclaimDtoType = typeof ReclaimDto.static

--- a/apps/back/src/modules/civilizations/reclaim.test.ts
+++ b/apps/back/src/modules/civilizations/reclaim.test.ts
@@ -1,0 +1,141 @@
+import { test, expect, mock, beforeEach } from 'bun:test'
+
+// `reclaimResources` ne touche, côté persistance, que les modèles Mongoose
+// suivants : lecture du user (pour vérifier la propriété), lecture des deux
+// civilisations via `findById`, écriture des ressources de la réceptrice
+// (`updateOne`), suppression de la civilisation abandonnée (`deleteOne` +
+// nettoyage des stats/cimetière), et nettoyage des références (`updateMany`).
+// On stub donc uniquement ces modèles, sans base de données réelle.
+
+const USER_ID = 'user-1'
+const RECEIVER_ID = 'civ-receiver'
+const TARGET_ID = 'civ-target'
+
+let userCivilizations: string[] = []
+let civsById: Record<string, any> = {}
+
+const updateOne = mock(async () => ({ acknowledged: true }))
+const deleteOne = mock(async () => ({ acknowledged: true, deletedCount: 1 }))
+const statsDeleteMany = mock(async () => ({ acknowledged: true }))
+const gravesDeleteMany = mock(async () => ({ acknowledged: true }))
+const updateMany = mock(async () => ({ acknowledged: true }))
+
+mock.module('../../libs/database/models', () => ({
+  UserModel: {
+    findOne: async () => ({ id: USER_ID, civilizations: userCivilizations }),
+  },
+  CivilizationModel: {
+    findById: (id: string) => civsById[id] ?? null,
+    updateOne,
+    deleteOne,
+    updateMany,
+  },
+  CivilizationStatsModel: { deleteMany: statsDeleteMany },
+  GraveModel: { deleteMany: gravesDeleteMany },
+  CombatLogModel: {},
+  PersonModel: {},
+  WorldModel: {},
+}))
+
+const { CivilizationService } = await import('./service')
+// `reclaimResources` n'utilise jamais le PeopleService : un stub vide suffit.
+const service = new CivilizationService({} as any)
+
+const makeCiv = (
+  id: string,
+  overrides: Partial<{
+    people: string[]
+    resources: { resourceType: string; quantity: number }[]
+  }> = {},
+) => ({
+  id,
+  name: id,
+  people: overrides.people ?? [],
+  resources: overrides.resources ?? [],
+})
+
+beforeEach(() => {
+  updateOne.mockClear()
+  deleteOne.mockClear()
+  statsDeleteMany.mockClear()
+  gravesDeleteMany.mockClear()
+  updateMany.mockClear()
+  userCivilizations = [RECEIVER_ID, TARGET_ID]
+  civsById = {
+    [RECEIVER_ID]: makeCiv(RECEIVER_ID, {
+      resources: [
+        { resourceType: 'wood', quantity: 100 },
+        { resourceType: 'stone', quantity: 50 },
+      ],
+    }),
+    [TARGET_ID]: makeCiv(TARGET_ID, {
+      people: [],
+      resources: [
+        { resourceType: 'wood', quantity: 30 },
+        { resourceType: 'raw_food', quantity: 200 },
+      ],
+    }),
+  }
+})
+
+test('succès : fusionne les ressources et dissout la civilisation abandonnée', async () => {
+  const result = await service.reclaimResources(USER_ID, RECEIVER_ID, TARGET_ID)
+
+  // La réceptrice est mise à jour avec les ressources fusionnées.
+  expect(updateOne).toHaveBeenCalledTimes(1)
+  const [filter, payload] = updateOne.mock.calls[0] as [any, any]
+  expect(filter).toEqual({ _id: RECEIVER_ID })
+  const byType = Object.fromEntries(
+    payload.resources.map((r: any) => [r.resourceType, r.quantity]),
+  )
+  expect(byType).toEqual({ wood: 130, stone: 50, raw_food: 200 })
+
+  // La civilisation abandonnée est supprimée et nettoyée.
+  expect(deleteOne).toHaveBeenCalledWith({ _id: TARGET_ID })
+  expect(statsDeleteMany).toHaveBeenCalledWith({ civilizationId: TARGET_ID })
+  expect(gravesDeleteMany).toHaveBeenCalledWith({ civilizationId: TARGET_ID })
+  expect(updateMany).toHaveBeenCalledTimes(1)
+
+  // Le résumé retourné liste les ressources récupérées.
+  const reclaimed = Object.fromEntries(
+    result.reclaimedResources.map((r) => [r.type, r.amount]),
+  )
+  expect(reclaimed).toEqual({ wood: 30, raw_food: 200 })
+})
+
+test('refus : la civilisation cible a encore des habitants', async () => {
+  civsById[TARGET_ID].people = ['person-1']
+
+  await expect(
+    service.reclaimResources(USER_ID, RECEIVER_ID, TARGET_ID),
+  ).rejects.toThrow('The target civilization still has inhabitants')
+  expect(updateOne).not.toHaveBeenCalled()
+  expect(deleteOne).not.toHaveBeenCalled()
+})
+
+test("refus : la civilisation cible n'appartient pas au joueur", async () => {
+  userCivilizations = [RECEIVER_ID]
+
+  await expect(
+    service.reclaimResources(USER_ID, RECEIVER_ID, TARGET_ID),
+  ).rejects.toThrow('Target civilization not found')
+  expect(updateOne).not.toHaveBeenCalled()
+  expect(deleteOne).not.toHaveBeenCalled()
+})
+
+test("refus : la civilisation réceptrice n'appartient pas au joueur", async () => {
+  userCivilizations = [TARGET_ID]
+
+  await expect(
+    service.reclaimResources(USER_ID, RECEIVER_ID, TARGET_ID),
+  ).rejects.toThrow('Civilization not found')
+  expect(updateOne).not.toHaveBeenCalled()
+})
+
+test('refus : on ne peut pas récupérer ses propres ressources', async () => {
+  await expect(
+    service.reclaimResources(USER_ID, RECEIVER_ID, RECEIVER_ID),
+  ).rejects.toThrow('A civilization cannot reclaim its own resources')
+  expect(updateOne).not.toHaveBeenCalled()
+  expect(deleteOne).not.toHaveBeenCalled()
+})

--- a/apps/back/src/modules/civilizations/service.ts
+++ b/apps/back/src/modules/civilizations/service.ts
@@ -659,6 +659,107 @@ export class CivilizationService {
     return { motherId: civilizationId, colonyId: colonyDoc._id.toString() }
   }
 
+  async reclaimResources(
+    userId: string,
+    civilizationId: string,
+    targetCivilizationId: string,
+  ) {
+    // 1. Les deux civilisations doivent appartenir au joueur.
+    const user = await UserModel.findOne({ _id: userId })
+    const ownedIds = (user?.civilizations ?? []).map(String)
+    if (!ownedIds.includes(civilizationId)) {
+      throw new Error('Civilization not found')
+    }
+    if (!ownedIds.includes(targetCivilizationId)) {
+      throw new Error('Target civilization not found')
+    }
+    if (civilizationId === targetCivilizationId) {
+      throw new Error('A civilization cannot reclaim its own resources')
+    }
+
+    // 2. Charger les deux documents.
+    const [receiver, target] = await Promise.all([
+      CivilizationModel.findById<MongoCivilizationType>(civilizationId),
+      CivilizationModel.findById<MongoCivilizationType>(targetCivilizationId),
+    ])
+    if (!receiver) throw new Error('Civilization not found')
+    if (!target) throw new Error('Target civilization not found')
+
+    // 3. On ne récupère les ressources que d'une civilisation abandonnée,
+    // c'est-à-dire dont plus personne n'est habitant.
+    if ((target.people?.length ?? 0) > 0) {
+      throw new Error('The target civilization still has inhabitants')
+    }
+
+    // 4. Fusionner les ressources de la cible dans la civilisation réceptrice.
+    const receiverResources = (
+      receiver.resources as { resourceType: ResourceTypes; quantity: number }[]
+    ).map((r) => ({ resourceType: r.resourceType, quantity: r.quantity }))
+    const reclaimedResources: { resourceType: ResourceTypes; quantity: number }[] = []
+
+    for (const resource of target.resources as {
+      resourceType: ResourceTypes
+      quantity: number
+    }[]) {
+      if (resource.quantity <= 0) continue
+      reclaimedResources.push({
+        resourceType: resource.resourceType,
+        quantity: resource.quantity,
+      })
+      const existing = receiverResources.find(
+        (r) => r.resourceType === resource.resourceType,
+      )
+      if (existing) {
+        existing.quantity += resource.quantity
+      } else {
+        receiverResources.push({
+          resourceType: resource.resourceType,
+          quantity: resource.quantity,
+        })
+      }
+    }
+
+    // 5. Sauver la civilisation réceptrice avec ses nouvelles ressources.
+    await CivilizationModel.updateOne(
+      { _id: civilizationId },
+      { resources: receiverResources },
+    )
+
+    // 6. Supprimer la civilisation abandonnée. Le hook `deleteOne` du schéma
+    // retire déjà la référence du monde et du joueur ; on nettoie en plus ses
+    // statistiques et son cimetière, comme le fait `delete`.
+    await CivilizationStatsModel.deleteMany({ civilizationId: targetCivilizationId })
+    await GraveModel.deleteMany({ civilizationId: targetCivilizationId })
+    await CivilizationModel.deleteOne({ _id: targetCivilizationId })
+
+    // 7. Nettoyer les références éventuelles vers la civilisation supprimée dans
+    // la configuration des autres civilisations (échanges ouverts, guerres) afin
+    // de ne pas laisser de liens fantômes (ex. une colonie issue de `colonize`).
+    await CivilizationModel.updateMany(
+      {
+        $or: [
+          { 'config.OPEN_EXCHANGE': targetCivilizationId },
+          { 'config.AT_WAR_WITH': targetCivilizationId },
+        ],
+      },
+      {
+        $pull: {
+          'config.OPEN_EXCHANGE': targetCivilizationId,
+          'config.AT_WAR_WITH': targetCivilizationId,
+        },
+      },
+    )
+
+    return {
+      receiverId: civilizationId,
+      targetId: targetCivilizationId,
+      reclaimedResources: reclaimedResources.map(({ resourceType, quantity }) => ({
+        type: resourceType,
+        amount: quantity,
+      })),
+    }
+  }
+
   async update(userId: string, civilizationId: string, body: UpdateCivilizationDtoType) {
     const user = await UserModel.findOne({ _id: userId }).populate<{
       civilizations: CivilizationType[]

--- a/apps/front/src/routes/my-civilizations/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/+page.svelte
@@ -13,8 +13,10 @@
 	} from '$lib/components/ui/form'
 	import {
 		callDeleteCivilization,
-		callGetCivilizations
+		callGetCivilizations,
+		callReclaimCivilizationResources
 	} from '../../services/sveltekit-api/civilization'
+	import { resourceNames } from '$lib/translations'
 	import { type CivilizationType, ResourceTypes } from '@ajustor/simulation'
 
 	interface Props {
@@ -41,6 +43,16 @@
 	let isDialogOpen = $state(false)
 	let deleteDialogOpen = $state(false)
 	let civilizationIdToDelete: string | null = null
+
+	// ── Récupération des ressources d'une civilisation abandonnée ──────────────
+	// Une civilisation dont plus personne n'est habitant peut voir ses ressources
+	// transférées vers une autre civilisation du joueur. La civilisation vidée est
+	// ensuite dissoute.
+	let reclaimDialogOpen = $state(false)
+	let reclaimSource = $state<CivilizationType | null>(null)
+	let reclaimCandidates = $state<CivilizationType[]>([])
+	let reclaimReceiverId = $state<string | null>(null)
+	let reclaiming = $state(false)
 
 	const { form: formData, enhance } = form
 
@@ -72,6 +84,40 @@
 
 	const getResourceQty = (civ: CivilizationType, type: ResourceTypes) =>
 		civ.resources.find((r) => r.type === type)?.quantity ?? 0
+
+	const openReclaimModal = (source: CivilizationType, allCivilizations: CivilizationType[]) => {
+		reclaimSource = source
+		reclaimCandidates = allCivilizations.filter((c) => c.id !== source.id)
+		reclaimReceiverId = reclaimCandidates[0]?.id ?? null
+		reclaimDialogOpen = true
+	}
+
+	const closeReclaimModal = () => {
+		reclaimDialogOpen = false
+		reclaimSource = null
+		reclaimCandidates = []
+		reclaimReceiverId = null
+	}
+
+	const reclaimResources = async () => {
+		if (!reclaimSource || !reclaimReceiverId || reclaiming) return
+		reclaiming = true
+		const loaderId = toast.loading('Récupération des ressources en cours')
+		try {
+			await callReclaimCivilizationResources(reclaimReceiverId, reclaimSource.id)
+		} catch (error) {
+			toast.dismiss(loaderId)
+			toast.error(error instanceof Error ? error.message : 'Erreur lors de la récupération')
+			reclaiming = false
+			return
+		}
+		toast.dismiss(loaderId)
+		toast.success('Ressources récupérées')
+		const { myCivilizations } = await callGetCivilizations()
+		data.myCivilizations = myCivilizations
+		reclaiming = false
+		closeReclaimModal()
+	}
 </script>
 
 <svelte:head>
@@ -181,6 +227,78 @@
 	</div>
 {/if}
 
+<!-- Reclaim resources modal -->
+{#if reclaimDialogOpen && reclaimSource}
+	{@const sourceResources = (reclaimSource.resources ?? []).filter((r) => r.quantity > 0)}
+	<div
+		role="presentation"
+		style="position:fixed; inset:0; z-index:50; background:rgba(40,25,10,.45); display:flex; align-items:center; justify-content:center; padding:16px;"
+		onclick={closeReclaimModal}
+	>
+		<div
+			style="background:radial-gradient(circle at 18% 12%, rgba(150,110,60,.06), transparent 45%), oklch(0.95 0.022 84); border:1px solid oklch(0.78 0.045 70); box-shadow:inset 0 0 0 5px oklch(0.93 0.03 84), inset 0 0 0 6px oklch(0.74 0.05 60), 0 20px 48px rgba(60,40,20,.24); border-radius:5px; padding:32px; width:100%; max-width:480px;"
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={(e) => e.stopPropagation()}
+			role="dialog"
+			aria-modal="true"
+			tabindex="-1"
+		>
+			<h2 style="font-family:'Marcellus',serif; font-size:22px; margin:0 0 8px; color:oklch(0.3 0.04 40);">♻️ Récupérer les ressources</h2>
+			<p style="font-size:16px; color:oklch(0.5 0.03 50); margin:0 0 20px; line-height:1.5;">
+				<strong>{reclaimSource.name}</strong> est abandonnée. Transférez ses ressources vers l'une de vos
+				civilisations. <strong>{reclaimSource.name}</strong> sera ensuite dissoute.
+			</p>
+
+			{#if sourceResources.length}
+				<div style="margin-bottom:20px; padding:12px 16px; border:1px solid oklch(0.85 0.03 60); border-radius:5px; background:oklch(0.99 0.008 84);">
+					<div style="font-family:'Marcellus',serif; font-size:14px; color:oklch(0.4 0.05 45); margin-bottom:8px;">Ressources à récupérer</div>
+					<div style="display:flex; flex-direction:column; gap:5px;">
+						{#each sourceResources as resource}
+							<div style="display:flex; justify-content:space-between; font-size:15px; color:oklch(0.35 0.04 42);">
+								<span>{resourceNames[resource.type as ResourceTypes] ?? resource.type}</span>
+								<span style="color:oklch(0.42 0.12 140); font-weight:600;">{resource.quantity.toLocaleString('fr-FR')}</span>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{:else}
+				<p style="font-size:15px; color:oklch(0.5 0.03 50); font-style:italic; margin:0 0 20px;">Cette civilisation ne possède aucune ressource à récupérer.</p>
+			{/if}
+
+			{#if reclaimCandidates.length}
+				<label style="display:block; font-family:'Marcellus',serif; font-size:14px; color:oklch(0.4 0.05 45); margin-bottom:6px;" for="reclaim-receiver">
+					Civilisation réceptrice
+				</label>
+				<select
+					id="reclaim-receiver"
+					bind:value={reclaimReceiverId}
+					style="width:100%; padding:10px 14px; border:1px solid oklch(0.74 0.05 60); border-radius:4px; background:oklch(0.98 0.01 84); color:oklch(0.3 0.04 40); font-family:'EB Garamond',serif; font-size:16px; margin-bottom:24px; box-sizing:border-box;"
+				>
+					{#each reclaimCandidates as candidate}
+						<option value={candidate.id}>{candidate.name} ({candidate.citizensCount} citoyens)</option>
+					{/each}
+				</select>
+			{:else}
+				<p style="font-size:15px; color:oklch(0.52 0.2 30); margin:0 0 24px;">Vous n'avez aucune autre civilisation pour recevoir ces ressources.</p>
+			{/if}
+
+			<div style="display:flex; gap:10px; justify-content:flex-end;">
+				<button
+					type="button"
+					onclick={closeReclaimModal}
+					style="padding:10px 18px; border:1px solid oklch(0.74 0.05 60); border-radius:4px; background:none; color:oklch(0.45 0.06 40); font-family:'Marcellus',serif; font-size:16px; cursor:pointer;"
+				>Annuler</button>
+				<button
+					type="button"
+					onclick={reclaimResources}
+					disabled={!reclaimReceiverId || reclaiming}
+					style="padding:10px 20px; border:none; border-radius:4px; background:{reclaimReceiverId && !reclaiming ? 'oklch(0.45 0.12 140)' : 'oklch(0.75 0.02 50)'}; color:oklch(0.95 0.02 84); font-family:'Marcellus',serif; font-size:16px; cursor:{reclaimReceiverId && !reclaiming ? 'pointer' : 'not-allowed'}; box-shadow:{reclaimReceiverId && !reclaiming ? '0 4px 12px rgba(30,80,30,.24)' : 'none'};"
+				>{reclaiming ? 'Récupération…' : 'Récupérer'}</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
 <div class="civ-page-wrapper">
 	<!-- Page header -->
 	<div style="display:flex; flex-wrap:wrap; justify-content:space-between; align-items:flex-end; gap:16px; margin-bottom:24px;" class="civ-animate-in">
@@ -257,6 +375,13 @@
 							</div>
 						</div>
 
+						{#if civ.citizensCount === 0 && myCivilizations.length > 1}
+							<button
+								onclick={() => openReclaimModal(civ, myCivilizations)}
+								title="Récupérer les ressources de cette civilisation abandonnée"
+								style="display:flex; align-items:center; justify-content:center; gap:6px; margin-bottom:8px; padding:9px; border:1px solid oklch(0.45 0.12 140); border-radius:4px; background:oklch(0.97 0.03 140 / 0.4); color:oklch(0.38 0.1 140); font-family:'Marcellus',serif; font-size:15px; cursor:pointer;"
+							>♻️ Récupérer les ressources</button>
+						{/if}
 						<div style="display:flex; gap:8px; margin-top:auto;">
 							<a href="/my-civilizations/{civ.id}" style="flex:1; display:flex; align-items:center; justify-content:center; padding:11px; border:1px solid oklch(0.5 0.13 34); border-radius:4px; background:none; color:oklch(0.45 0.12 34); font-family:'Marcellus',serif; font-size:16px; cursor:pointer; text-decoration:none;">Voir le détail</a>
 							<button onclick={() => openDeleteModal(civ.id)} title="Supprimer" style="padding:11px 14px; border:1px solid oklch(0.52 0.2 30); border-radius:4px; background:none; color:oklch(0.52 0.2 30); cursor:pointer; font-size:18px;">✕</button>

--- a/apps/front/src/routes/my-civilizations/+server.ts
+++ b/apps/front/src/routes/my-civilizations/+server.ts
@@ -1,11 +1,32 @@
 export const prerender = false
 import { json } from '@sveltejs/kit'
-import { deleteCivilization, getMyCivilizations } from '../../services/api/civilization-api.js'
+import {
+  deleteCivilization,
+  getMyCivilizations,
+  reclaimCivilizationResources,
+} from '../../services/api/civilization-api.js'
 
 export async function DELETE({ cookies, request }) {
   const { civilizationId } = await request.json()
   await deleteCivilization(cookies.get('auth') ?? '', civilizationId)
   return json({}, { status: 200 })
+}
+
+export async function POST({ cookies, request }) {
+  const { civilizationId, targetCivilizationId } = await request.json()
+  try {
+    const result = await reclaimCivilizationResources(
+      cookies.get('auth') ?? '',
+      civilizationId,
+      targetCivilizationId,
+    )
+    return json(result ?? {}, { status: 200 })
+  } catch (error) {
+    const message =
+      (error as { value?: { error?: string } })?.value?.error ??
+      (error instanceof Error ? error.message : 'Erreur lors de la récupération des ressources')
+    return json({ error: message }, { status: 400 })
+  }
 }
 
 

--- a/apps/front/src/services/api/civilization-api.ts
+++ b/apps/front/src/services/api/civilization-api.ts
@@ -149,6 +149,28 @@ export const getCemetery = async (
   return data
 }
 
+export const reclaimCivilizationResources = async (
+  authToken: string,
+  civilizationId: string,
+  targetCivilizationId: string,
+) => {
+  const { data, error } = await client
+    .civilizations({ civilizationId })
+    .reclaim.post(
+      { targetCivilizationId },
+      {
+        headers: { authorization: `Bearer ${authToken}` },
+      },
+    )
+
+  if (error) {
+    console.error(error)
+    throw error
+  }
+
+  return data
+}
+
 export const colonizeCivilization = async (
   authToken: string,
   civilizationId: string,

--- a/apps/front/src/services/sveltekit-api/civilization.ts
+++ b/apps/front/src/services/sveltekit-api/civilization.ts
@@ -4,6 +4,23 @@ export const callDeleteCivilization = async (civilizationId: string) => fetch('m
   body: JSON.stringify({ civilizationId })
 })
 
+export const callReclaimCivilizationResources = async (
+  civilizationId: string,
+  targetCivilizationId: string
+) => {
+  const response = await fetch('my-civilizations', {
+    method: 'POST',
+    body: JSON.stringify({ civilizationId, targetCivilizationId })
+  })
+
+  const body = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(body?.error ?? 'Erreur lors de la récupération des ressources')
+  }
+
+  return body
+}
+
 export const callGetCivilizations = async () => {
   const response = await fetch('my-civilizations', {
     method: 'GET'


### PR DESCRIPTION
## Résumé

Nouvelle fonctionnalité permettant à un joueur de **récupérer les ressources d'une de ses civilisations devenue abandonnée** (dont plus personne n'est habitant) en les transférant vers une autre de ses civilisations. La civilisation vidée est ensuite dissoute.

L'action est **restreinte aux civilisations appartenant au joueur** : la civilisation source (abandonnée) comme la civilisation réceptrice doivent toutes deux lui appartenir.

## Détails

### Backend (`apps/back`)
- `service.ts` : nouvelle méthode `reclaimResources(userId, civilizationId, targetCivilizationId)` qui
  - vérifie que les deux civilisations appartiennent au joueur et qu'elles sont distinctes ;
  - refuse l'opération si la civilisation cible a encore des habitants ;
  - fusionne les ressources de la cible dans la civilisation réceptrice ;
  - supprime la civilisation abandonnée (stats + cimetière nettoyés, le hook `deleteOne` retirant déjà la référence du monde et du joueur) ;
  - nettoie les références éventuelles vers la civilisation supprimée dans la config des autres civilisations (`OPEN_EXCHANGE`, `AT_WAR_WITH`).
- `index.ts` : route `POST /civilizations/:civilizationId/reclaim`.
- `reclaim.dto.ts` : DTO de la requête (`targetCivilizationId`).
- `reclaim.test.ts` : tests du succès et des cas de refus (cible peuplée, non‑propriété de la cible/réceptrice, même civilisation).

### Frontend (`apps/front`)
- Bouton « ♻️ Récupérer les ressources » affiché sur les cartes des civilisations sans habitant dans **Mes civilisations**.
- Modale de récupération : aperçu des ressources transférées et sélection de la civilisation réceptrice.
- Wrappers API (`civilization-api.ts`, `sveltekit-api/civilization.ts`) et handler `POST` sur la route `my-civilizations`.

## Tests
- `bun test apps/back` → 20 passants, 0 échec.
- `svelte-check` : aucune nouvelle erreur introduite sur les fichiers modifiés (les erreurs restantes sont préexistantes / liées aux variables d'env. non définies lors du check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV3usoThDfZ8o1DZpBgKxa)_