### PR TITLE
feat(people): ajouter le pourcentage d'enfants au rapport homme/femme

### DIFF
--- a/apps/back/src/modules/people/index.ts
+++ b/apps/back/src/modules/people/index.ts
@@ -94,12 +94,13 @@ export const peopleModule = new Elysia({ prefix: '/people' })
     return { menAndWomen, pregnantWomen, jobs }
   })
   .get('/:civilizationId/stats/peopleRatio', async ({ peopleService, params: { civilizationId } }) => {
-    const [menAndWomen, pregnantWomen] = await Promise.all([
+    const [menAndWomen, pregnantWomen, children] = await Promise.all([
       peopleService.countGenders(civilizationId),
-      peopleService.countPregnant(civilizationId)
+      peopleService.countPregnant(civilizationId),
+      peopleService.countChildren(civilizationId)
     ])
 
-    return { menAndWomen, pregnantWomen }
+    return { menAndWomen, pregnantWomen, children }
   })
   .get('/:civilizationId/stats/jobs', async ({ peopleService, params: { civilizationId } }) => {
     const jobs: { [key in OccupationTypes]?: number } = {}

--- a/apps/back/src/modules/people/service.ts
+++ b/apps/back/src/modules/people/service.ts
@@ -190,6 +190,15 @@ export class PeopleService {
     return PersonModel.find<PeopleType>({ _id: { $in: civilization.people } }).countDocuments({ child: { $ne: null } })
   }
 
+  public async countChildren(civilizationId: string): Promise<number> {
+    const civilization = await CivilizationModel.findById<MongoCivilizationType>(civilizationId, 'people')
+    if (!civilization) {
+      throw new Error(`No civilization found for ${civilizationId}`)
+    }
+
+    return PersonModel.find<PeopleType>({ _id: { $in: civilization.people } }).countDocuments({ occupation: OccupationTypes.CHILD })
+  }
+
   public async countPeopleWithJob(civilizationId: string, occupation: OccupationTypes): Promise<number> {
     const civilization = await CivilizationModel.findById<MongoCivilizationType>(civilizationId, 'people')
     if (!civilization) {

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -536,6 +536,7 @@
 							{@const men = peopleRatio.menAndWomen.men}
 							{@const women = peopleRatio.menAndWomen.women}
 							{@const pregnant = peopleRatio.pregnantWomen}
+							{@const children = peopleRatio.children ?? 0}
 							{@const total = men + women}
 							{@const ratio = women > 0 ? (men / women).toFixed(2) : '─'}
 							<div style="display:grid; grid-template-columns:260px 1fr; gap:20px; align-items:start;">
@@ -561,6 +562,8 @@
 												<span style="font-weight:600; color:oklch(0.32 0.04 40);">{ratio}</span>
 												<span style="color:oklch(0.5 0.04 50);">Pour 100 femmes</span>
 												<span style="font-weight:600; color:oklch(0.32 0.04 40);">{women > 0 ? Math.round(men / women * 100) : '─'} hommes</span>
+												<span style="color:oklch(0.5 0.04 50);">Enfants</span>
+												<span style="font-weight:600; color:oklch(0.32 0.04 40);">{fmt(children)} ({pct(children, total)}%)</span>
 												<span style="color:oklch(0.5 0.04 50);">Total</span>
 												<span style="font-weight:600; color:oklch(0.32 0.04 40);">{fmt(total)}</span>
 											</div>


### PR DESCRIPTION
## Résumé

Ajoute une information sur le pourcentage d'enfants dans le rapport « Rapport homme / femme ».

## Changements

- **Backend (`apps/back/src/modules/people/service.ts`)** : nouvelle méthode `countChildren` qui compte les citoyens dont l'occupation est `CHILD` (même définition que `childrenCount` côté simulation).
- **Backend (`apps/back/src/modules/people/index.ts`)** : l'endpoint `GET /:civilizationId/stats/peopleRatio` renvoie désormais aussi le champ `children`.
- **Frontend (`apps/front/.../[slug]/+page.svelte`)** : le panneau de répartition affiche, dans la section « Équilibre », le nombre d'enfants et leur pourcentage de la population.

Le type du champ `children` se propage automatiquement au frontend via le client Eden Treaty typé sur l'`App` du backend ; un garde `?? 0` assure la rétrocompatibilité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT1hAmj1ZgEVxxQrqmipYS)_