### PR TITLE
refactor(front): retirer l'aperçu du cimetière de la page civilisation

### DIFF
--- a/apps/front/src/routes/my-civilizations/[slug]/+page.server.ts
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.server.ts
@@ -5,7 +5,6 @@ import {
   getMyCivilizationFromId,
   getCivilizationWorld,
   getCombatLogs,
-  getCemetery,
 } from '../../../services/api/civilization-api'
 import { redirect } from '@sveltejs/kit'
 import type { PageServerLoad } from './$types'
@@ -44,7 +43,6 @@ export const load: PageServerLoad = async ({ cookies, params }) => {
         civilization: getCivilizationStats(cookies.get('auth') ?? '', params.slug),
       },
       combatLogs: getCombatLogs(cookies.get('auth') ?? '', params.slug, 5, 0),
-      cemetery: getCemetery(cookies.get('auth') ?? '', params.slug, 20, 0),
     },
   }
 }

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -8,12 +8,11 @@
 		BuildingTypes,
 		type OccupationTypes,
 		type PeopleType,
-		type DeathCause,
 		Events,
 		TECH_TREE
 	} from '@ajustor/simulation'
 	import BuildingsTable from './datatables/buildings-table.svelte'
-	import { OCCUPATIONS, resourceNames, eventsName, eventsDescription, buildingNames, deathCauseNames } from '$lib/translations'
+	import { OCCUPATIONS, resourceNames, eventsName, eventsDescription, buildingNames } from '$lib/translations'
 	import PeopleTable from './datatables/people-table.svelte'
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 	import { callGetPeople } from '../../../services/sveltekit-api/people'
@@ -52,7 +51,6 @@
 	let jobsPromise = $state(data.lazy.stats.jobs)
 	let peopleRatioPromise = $state(data.lazy.stats.peopleRatio)
 	let combatLogsPromise = $state(data.lazy.combatLogs)
-	let cemeteryPromise = $state(data.lazy.cemetery)
 
 	const refreshStats = () => {
 		const stats = callGetStats(data.civilization.id)
@@ -60,7 +58,6 @@
 		jobsPromise = stats.then((s) => s.jobs)
 		peopleRatioPromise = stats.then((s) => s.peopleRatio)
 		combatLogsPromise = stats.then((s) => s.combatLogs)
-		cemeteryPromise = stats.then((s) => s.cemetery)
 	}
 
 	// Which panel is expanded: null = closed
@@ -945,44 +942,6 @@
 				{/if}
 			{:catch}
 				<p style="color:oklch(0.5 0.18 30); font-size:15px;">Impossible de charger les conflits.</p>
-			{/await}
-		</div>
-
-		<!-- Cemetery (aperçu — page dédiée) -->
-		<div class="civ-inner-card" style="margin-top:24px;">
-			<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
-				<h2 class="civ-section-title" style="margin:0;">Cimetière</h2>
-				<a href="/my-civilizations/{data.civilization.id}/cemetery" style="font-size:15px; color:oklch(0.5 0.13 34); font-family:'EB Garamond',serif; text-decoration:none;">Voir le cimetière →</a>
-			</div>
-
-			{#await cemeteryPromise}
-				<p style="color:oklch(0.55 0.03 50); font-size:15px;">Chargement…</p>
-			{:then cemetery}
-				{#if !cemetery || !cemetery.graves || cemetery.graves.length === 0}
-					<p style="color:oklch(0.55 0.03 50); font-size:15px; font-style:italic;">Aucun défunt pour le moment.</p>
-				{:else}
-					<!-- Cause breakdown -->
-					<div style="display:flex; flex-wrap:wrap; gap:8px; margin-bottom:16px;">
-						{#each Object.entries(cemetery.causes) as [cause, count]}
-							<span style="font-size:14px; padding:4px 12px; border-radius:3px; background:oklch(0.92 0.03 60); color:oklch(0.35 0.04 42);">
-								{deathCauseNames[cause as DeathCause] ?? cause} : <strong>{count}</strong>
-							</span>
-						{/each}
-					</div>
-					<!-- Recent deaths (aperçu des plus récents) -->
-					<div style="display:flex; flex-direction:column; gap:6px;">
-						{#each cemetery.graves.slice(0, 6) as grave}
-							<div style="display:flex; align-items:center; gap:12px; padding:8px 14px; border-radius:4px; background:oklch(0.97 0.01 84); border:1px solid oklch(0.85 0.03 70);">
-								<span style="font-size:16px; flex-shrink:0;">🪦</span>
-								<span style="flex:1; min-width:0; font-family:'Marcellus',serif; font-size:15px; color:oklch(0.35 0.04 40);">{grave.name}</span>
-								<span style="font-size:13px; color:oklch(0.5 0.06 40);">{deathCauseNames[grave.cause as DeathCause] ?? grave.cause}</span>
-								<span style="font-size:13px; color:oklch(0.55 0.03 50); flex-shrink:0;">Mois {grave.month}</span>
-							</div>
-						{/each}
-					</div>
-				{/if}
-			{:catch}
-				<p style="color:oklch(0.5 0.18 30); font-size:15px;">Impossible de charger le cimetière.</p>
 			{/await}
 		</div>
 	</div>


### PR DESCRIPTION
## Résumé

Retire le petit aperçu/tableau du cimetière affiché en bas de la page d'une civilisation. Le **bouton « 🪦 Cimetière »** dans l'en-tête et la **page dédiée du cimetière** restent inchangés.

## Changements

- **`apps/front/.../[slug]/+page.svelte`** : suppression de la section d'aperçu « Cimetière » (résumé des causes + 6 derniers défunts). Nettoyage des symboles devenus inutilisés : état `cemeteryPromise`, imports `deathCauseNames` et `DeathCause`.
- **`apps/front/.../[slug]/+page.server.ts`** : suppression de la requête lazy `cemetery` (et de l'import `getCemetery`) qui n'est plus consommée par la page, évitant un appel réseau inutile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT1hAmj1ZgEVxxQrqmipYS)_