### PR TITLE
feat(marché) : notifier les joueurs lors d'une mise en vente

### DIFF
--- a/apps/back/src/modules/trade-offers/service.ts
+++ b/apps/back/src/modules/trade-offers/service.ts
@@ -1,8 +1,30 @@
 import type { CivilizationType } from '@ajustor/simulation'
-import { CivilizationModel, TradeOfferModel, UserModel } from '../../libs/database/models'
+import {
+  CivilizationModel,
+  TradeOfferModel,
+  UserModel,
+  WorldModel,
+} from '../../libs/database/models'
 import { canFulfill, applyResourceChanges, type ResourceAmount } from './tradeLogic'
+import { pushSender } from '../../libs/services/pushSender'
 
 type StoredResource = { resourceType: string; quantity: number }
+
+// French resource labels, mirrored from the front (`lib/translations/resources.ts`)
+// so push notifications read naturally instead of exposing raw resource keys.
+const RESOURCE_LABELS: Record<string, string> = {
+  food: 'Nourriture',
+  wood: 'Bois',
+  stone: 'Pierre',
+  plank: 'Planche',
+  charcoal: 'Charbon',
+  cookedFood: 'Nourriture préparée',
+}
+
+const formatResourceList = (items: ResourceAmount[]): string =>
+  items
+    .map((r) => `${r.quantity} ${RESOURCE_LABELS[r.resourceType] ?? r.resourceType}`)
+    .join(', ')
 
 export type CreateTradeOfferInput = {
   worldId: string
@@ -27,7 +49,7 @@ export class TradeOfferService {
 
   async create(userId: string, input: CreateTradeOfferInput) {
     await this.assertOwnership(userId, input.fromCivilizationId)
-    return TradeOfferModel.create({
+    const offer = await TradeOfferModel.create({
       worldId: input.worldId,
       fromCivilizationId: input.fromCivilizationId,
       toCivilizationId: input.toCivilizationId ?? null,
@@ -35,6 +57,68 @@ export class TradeOfferService {
       want: input.want,
       status: 'open',
     })
+
+    // Notify the other players that a new offer is up for grabs. Never let a
+    // push failure break offer creation.
+    try {
+      await this.notifyMarketSale(userId, input)
+    } catch (error) {
+      console.error('[TradeOfferService] Failed to send market notification', error)
+    }
+
+    return offer
+  }
+
+  /**
+   * Sends a push notification when a player puts resources up for sale on the
+   * market. An open offer notifies every other player who owns a civilization in
+   * the world; a targeted offer notifies only the addressed civilization's owner.
+   * The seller is always excluded from the recipients.
+   */
+  private async notifyMarketSale(
+    sellerUserId: string,
+    input: CreateTradeOfferInput,
+  ): Promise<void> {
+    const sellerCiv = await CivilizationModel.findById(input.fromCivilizationId, {
+      name: 1,
+    }).lean()
+    const sellerName = sellerCiv?.name ?? 'Une civilisation'
+
+    let recipientIds: string[]
+    if (input.toCivilizationId) {
+      const owner = await UserModel.findOne(
+        { civilizations: input.toCivilizationId },
+        { _id: 1 },
+      ).lean()
+      recipientIds = owner ? [String(owner._id)] : []
+    } else {
+      const world = await WorldModel.findById(input.worldId, {
+        civilizations: 1,
+      }).lean()
+      const owners = await UserModel.find(
+        { civilizations: { $in: world?.civilizations ?? [] } },
+        { _id: 1 },
+      ).lean()
+      recipientIds = owners.map((owner) => String(owner._id))
+    }
+
+    // Deduplicate (a player may own several civilizations) and drop the seller.
+    const recipients = [...new Set(recipientIds)].filter(
+      (id) => id !== sellerUserId,
+    )
+
+    const giveLabel = formatResourceList(input.give)
+    const wantLabel = formatResourceList(input.want)
+
+    await Promise.all(
+      recipients.map((userId) =>
+        pushSender.sendToUser(userId, {
+          title: '🏛️ Nouvelle offre au marché',
+          body: `${sellerName} propose ${giveLabel} contre ${wantLabel}.`,
+          url: `/worlds/${input.worldId}/market`,
+        }),
+      ),
+    )
   }
 
   async listOpenByWorld(worldId: string) {

--- a/apps/front/src/lib/components/NotificationToggle.svelte
+++ b/apps/front/src/lib/components/NotificationToggle.svelte
@@ -35,14 +35,14 @@
 		try {
 			if (pushState === 'enabled') {
 				pushState = await disablePush(authToken)
-				toast.success("Notifications d'attaque désactivées")
+				toast.success('Notifications désactivées')
 			} else {
 				pushState = await enablePush(authToken)
 				if (pushState === 'enabled') {
-					toast.success("Notifications d'attaque activées")
+					toast.success('Notifications activées')
 				} else if (pushState === 'denied') {
 					toast.error(
-						'Les notifications sont bloquées dans votre navigateur. Autorisez-les pour être prévenu des attaques.'
+						'Les notifications sont bloquées dans votre navigateur. Autorisez-les pour être prévenu en temps réel.'
 					)
 				}
 			}
@@ -60,17 +60,18 @@
 </script>
 
 <div class="civ-inner-card">
-	<h2 class="civ-section-title">Notifications d'attaque</h2>
+	<h2 class="civ-section-title">Notifications</h2>
 
 	{#if pushState === 'unsupported'}
 		<p style="font-size:15px; color:oklch(0.5 0.03 50); margin:0;">
 			Votre navigateur ne supporte pas les notifications push. Installez l'application
-			(PWA) ou utilisez un navigateur compatible pour être prévenu des attaques.
+			(PWA) ou utilisez un navigateur compatible pour rester informé.
 		</p>
 	{:else}
 		<p style="font-size:15px; color:oklch(0.48 0.03 50); margin:0 0 14px;">
 			Recevez une notification dès qu'une civilisation vous déclare la guerre, pour avoir
-			le temps de préparer vos défenses.
+			le temps de préparer vos défenses, ou lorsqu'un joueur met des ressources en vente
+			sur le marché du monde. Vous pouvez activer les notifications sur plusieurs appareils.
 		</p>
 
 		{#if pushState === 'denied'}


### PR DESCRIPTION
## Objectif

Envoyer une notification push lorsqu'un joueur met des ressources en vente sur le marché du monde, en réutilisant l'infrastructure Web Push (VAPID) déjà en place pour les notifications de guerre.

## Changements

Dans `apps/back/src/modules/trade-offers/service.ts` :

- `create()` déclenche désormais une notification après la création de l'offre.
- Nouvelle méthode privée `notifyMarketSale()` :
  - **Offre ouverte à tous** → notifie chaque autre joueur possédant une civilisation dans le monde.
  - **Offre ciblée** → notifie uniquement le propriétaire de la civilisation visée.
  - Le vendeur est toujours exclu et les destinataires sont dédupliqués (un joueur peut posséder plusieurs civilisations).
- La notification contient le nom du vendeur, les ressources proposées/demandées (libellés FR) et un lien vers `/worlds/:worldId/market`.
- Les échecs d'envoi sont capturés afin de ne jamais bloquer la création de l'offre.

## Notes

- Les libellés de ressources en français reprennent ceux du front (`lib/translations/resources.ts`).
- À propos du multi-appareils : le système supporte déjà plusieurs appareils par joueur. Les abonnements sont stockés dans un tableau `pushSubscriptions` sur l'utilisateur, l'endpoint `/push/register` fait un upsert par `endpoint`, et `pushSender.sendToUser` envoie à **tous** les appareils enregistrés. Aucun changement nécessaire de ce côté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzv73JcNWg9ArbEvXDfbFi)_