### PR TITLE
feat(front): page de mises à jour et choix du bâtiment dans le bloc constructions

### DIFF
--- a/apps/front/src/hooks.server.ts
+++ b/apps/front/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import { redirect, type Handle } from '@sveltejs/kit'
 import { getUser } from './services/api/user-api'
-const unprotectedRoutes = ['/', '/login', '/rules', '/register', '/i-forgot', '/favicon.ico']
+const unprotectedRoutes = ['/', '/login', '/rules', '/register', '/i-forgot', '/changelog', '/favicon.ico']
 
 export const handle: Handle = async ({ event, resolve }) => {
 	if (unprotectedRoutes.includes(event.url.pathname)) {

--- a/apps/front/src/lib/changelog.ts
+++ b/apps/front/src/lib/changelog.ts
@@ -1,0 +1,107 @@
+// Journal des mises à jour présenté aux joueurs sur la page /changelog.
+// Ajoutez les nouvelles entrées en haut de la liste (la plus récente d'abord).
+// `date` est au format AAAA-MM-JJ pour pouvoir être triée/affichée proprement.
+
+export type ChangeKind = 'feature' | 'improvement' | 'fix'
+
+export type ChangelogChange = {
+	kind: ChangeKind
+	text: string
+}
+
+export type ChangelogEntry = {
+	date: string
+	title: string
+	changes: ChangelogChange[]
+}
+
+export const changeKindLabels: Record<ChangeKind, string> = {
+	feature: 'Nouveauté',
+	improvement: 'Amélioration',
+	fix: 'Correction'
+}
+
+export const changeKindColors: Record<ChangeKind, string> = {
+	feature: 'oklch(0.5 0.13 145)',
+	improvement: 'oklch(0.5 0.12 250)',
+	fix: 'oklch(0.5 0.15 34)'
+}
+
+export const changelog: ChangelogEntry[] = [
+	{
+		date: '2026-06-29',
+		title: 'Constructions plus accessibles & journal des mises à jour',
+		changes: [
+			{
+				kind: 'improvement',
+				text: 'Le choix du prochain bâtiment à construire se fait désormais directement depuis le bloc « Constructions en cours » de la civilisation, sans passer par les réglages.'
+			},
+			{
+				kind: 'feature',
+				text: 'Ajout de cette page de journal des mises à jour pour suivre les nouveautés du jeu.'
+			}
+		]
+	},
+	{
+		date: '2026-06-15',
+		title: 'Vie du marché',
+		changes: [
+			{
+				kind: 'feature',
+				text: 'Les joueurs sont désormais notifiés lorsqu’une ressource est mise en vente sur le marché.'
+			},
+			{
+				kind: 'improvement',
+				text: 'L’aperçu du cimetière a été retiré de la page de civilisation pour la rendre plus lisible.'
+			},
+			{
+				kind: 'improvement',
+				text: 'Le rapport homme/femme affiche maintenant le pourcentage d’enfants.'
+			}
+		]
+	},
+	{
+		date: '2026-05-30',
+		title: 'Colonies, recherche et cimetière',
+		changes: [
+			{
+				kind: 'feature',
+				text: 'Arbre de technologies : recherchez des améliorations pour booster production, stockage, militaire et natalité.'
+			},
+			{
+				kind: 'feature',
+				text: 'Possibilité de récupérer les ressources d’une civilisation abandonnée.'
+			},
+			{
+				kind: 'feature',
+				text: 'Un cimetière retrace désormais l’histoire de vos citoyens disparus.'
+			},
+			{
+				kind: 'improvement',
+				text: 'Un sélecteur de période a été ajouté aux graphiques de progression.'
+			}
+		]
+	},
+	{
+		date: '2026-05-10',
+		title: 'Suivi en direct & confort de jeu',
+		changes: [
+			{
+				kind: 'feature',
+				text: 'Rafraîchissement automatique en direct : les civilisations se mettent à jour dès que le monde avance d’un mois.'
+			},
+			{
+				kind: 'feature',
+				text: 'Récapitulatif « pendant ton absence » au retour dans une civilisation.'
+			},
+			{
+				kind: 'feature',
+				text: 'Notifications push pour prévenir les défenseurs d’une attaque imminente.'
+			},
+			{
+				kind: 'improvement',
+				text: 'Les citoyens portent désormais des noms, et un fil d’Ariane facilite la navigation.'
+			}
+		]
+	}
+]

--- a/apps/front/src/routes/Header.svelte
+++ b/apps/front/src/routes/Header.svelte
@@ -11,7 +11,8 @@
 	const navLinks = [
 		{ url: '/', label: 'Les mondes', match: (p: string) => p === '/' || p.startsWith('/worlds') },
 		{ url: '/my-civilizations', label: 'Mes civilisations', match: (p: string) => p.startsWith('/my-civilizations') },
-		{ url: '/rules', label: 'Les règles', match: (p: string) => p.startsWith('/rules') }
+		{ url: '/rules', label: 'Les règles', match: (p: string) => p.startsWith('/rules') },
+		{ url: '/changelog', label: 'Mises à jour', match: (p: string) => p.startsWith('/changelog') }
 	]
 
 	let menuOpen = $state(false)

--- a/apps/front/src/routes/changelog/+page.svelte
+++ b/apps/front/src/routes/changelog/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { changelog, changeKindLabels, changeKindColors } from '$lib/changelog'
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
+
+	const formatDate = (date: string) =>
+		new Date(date).toLocaleDateString('fr-FR', {
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric'
+		})
+</script>
+
+<svelte:head>
+	<title>Mises à jour — Civilizations</title>
+	<meta
+		name="description"
+		content="Découvrez les dernières nouveautés et améliorations du jeu Civilizations."
+	/>
+</svelte:head>
+
+<div class="civ-page-wrapper">
+	<Breadcrumb items={[{ label: 'Mises à jour' }]} />
+
+	<div
+		class="civ-card"
+		style="max-width:820px; margin:0 auto; display:flex; flex-direction:column; gap:8px;"
+	>
+		<h1
+			style="font-family:'Tangerine',cursive; font-size:clamp(34px,6vw,46px); margin:0; color:oklch(0.3 0.04 40);"
+		>
+			Journal des mises à jour
+		</h1>
+		<p style="font-size:17px; color:oklch(0.46 0.03 50); margin:0 0 8px;">
+			Retrouvez ici les dernières nouveautés, améliorations et corrections apportées au jeu.
+		</p>
+
+		<div style="display:flex; flex-direction:column; gap:24px; margin-top:8px;">
+			{#each changelog as entry (entry.date + entry.title)}
+				<div class="civ-inner-card">
+					<div
+						style="display:flex; flex-wrap:wrap; align-items:baseline; justify-content:space-between; gap:8px; margin-bottom:14px;"
+					>
+						<h2 class="civ-section-title" style="margin:0;">{entry.title}</h2>
+						<span style="font-size:14px; color:oklch(0.5 0.04 50);">{formatDate(entry.date)}</span>
+					</div>
+
+					<div style="display:flex; flex-direction:column; gap:10px;">
+						{#each entry.changes as change}
+							<div style="display:flex; align-items:flex-start; gap:10px;">
+								<span
+									style="flex-shrink:0; font-size:11px; letter-spacing:.06em; text-transform:uppercase; font-weight:600; color:oklch(0.97 0.02 84); background:{changeKindColors[
+										change.kind
+									]}; border-radius:999px; padding:3px 10px; min-width:96px; text-align:center;"
+									>{changeKindLabels[change.kind]}</span
+								>
+								<span style="font-size:16px; color:oklch(0.36 0.04 42); line-height:1.45;"
+									>{change.text}</span
+								>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.server.ts
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.server.ts
@@ -5,9 +5,10 @@ import {
   getMyCivilizationFromId,
   getCivilizationWorld,
   getCombatLogs,
+  updateCivilization,
 } from '../../../services/api/civilization-api'
-import { redirect } from '@sveltejs/kit'
-import type { PageServerLoad } from './$types'
+import { fail, redirect } from '@sveltejs/kit'
+import type { Actions, PageServerLoad } from './$types'
 import {
   getPeopleFromCivilizationPaginated,
   getCivilizationPeopleJobsStats,
@@ -46,3 +47,24 @@ export const load: PageServerLoad = async ({ cookies, params }) => {
     },
   }
 }
+
+export const actions: Actions = {
+  // Choix du prochain bâtiment à construire, déplacé depuis la page de
+  // configuration vers le bloc « Constructions en cours » de la civilisation.
+  updateNextBuilding: async ({ cookies, params, request }) => {
+    const formData = await request.formData()
+    const raw = formData.get('nextBuildingToBuild')
+    const nextBuildingToBuild = raw ? String(raw) : null
+
+    try {
+      await updateCivilization(cookies.get('auth') ?? '', params.slug, {
+        nextBuildingToBuild,
+      })
+      return { success: true }
+    } catch (requestError) {
+      return fail(requestError?.status ?? 500, {
+        message: requestError?.value ?? 'Une erreur est survenue',
+      })
+    }
+  },
+} satisfies Actions

--- a/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/+page.svelte
@@ -9,7 +9,18 @@
 		type OccupationTypes,
 		type PeopleType,
 		Events,
-		TECH_TREE
+		TECH_TREE,
+		House,
+		Farm,
+		Kiln,
+		Sawmill,
+		Mine,
+		Campfire,
+		Cache,
+		Wall,
+		Library,
+		getBuildingGate,
+		getTechNode
 	} from '@ajustor/simulation'
 	import BuildingsTable from './datatables/buildings-table.svelte'
 	import { OCCUPATIONS, resourceNames, eventsName, eventsDescription, buildingNames } from '$lib/translations'
@@ -18,6 +29,8 @@
 	import { callGetPeople } from '../../../services/sveltekit-api/people'
 	import { callGetStats } from '../../../services/sveltekit-api/civilization'
 	import { onMount } from 'svelte'
+	import { enhance } from '$app/forms'
+	import { toast } from 'svelte-sonner'
 	import { invalidateAll } from '$app/navigation'
 	import { PUBLIC_BACK_URL } from '$env/static/public'
 	import RecapModal from '$lib/components/RecapModal.svelte'
@@ -273,6 +286,60 @@
 			: monthsRemaining === 1
 				? 'Prête le mois prochain'
 				: `Prête dans ${monthsRemaining} mois`
+
+	// ── Prochain bâtiment à construire ──────────────────────────────────────────
+	// Déplacé depuis la page de configuration : le joueur choisit ici le bâtiment
+	// que la civilisation cherchera à construire en priorité.
+	type BuildingMeta = {
+		constructionCosts?: { resource: ResourceTypes; amount: number }[]
+		workerRequiredToBuild?: { occupation: OccupationTypes; amount: number }[]
+		timeToBuild?: number
+	}
+	const BUILDING_CLASSES: Record<BuildingTypes, BuildingMeta> = {
+		[BuildingTypes.HOUSE]: House,
+		[BuildingTypes.FARM]: Farm,
+		[BuildingTypes.KILN]: Kiln,
+		[BuildingTypes.SAWMILL]: Sawmill,
+		[BuildingTypes.MINE]: Mine,
+		[BuildingTypes.CAMPFIRE]: Campfire,
+		[BuildingTypes.CACHE]: Cache,
+		[BuildingTypes.WALL]: Wall,
+		[BuildingTypes.LIBRARY]: Library
+	}
+
+	// Bâtiments verrouillés par l'arbre de technologies : pour chaque type gardé
+	// par une techno non encore recherchée, on conserve le nom (FR) de cette techno.
+	const lockedBuildings = $derived.by(() => {
+		const locked = new Map<BuildingTypes, string>()
+		for (const buildingType of Object.values(BuildingTypes)) {
+			const gate = getBuildingGate(buildingType)
+			if (gate && !researchedTechs.includes(gate)) {
+				locked.set(buildingType, getTechNode(gate)?.name ?? gate)
+			}
+		}
+		return locked
+	})
+
+	// Valeur sélectionnée. Initialisée depuis la config persistée et resynchronisée
+	// quand celle-ci change (après enregistrement ou avancée du monde), sans écraser
+	// une modification en cours de l'utilisateur (l'effet ne dépend que de la valeur
+	// persistée).
+	let selectedBuilding = $state<string>(data.civilization.config?.NEXT_BUILDING_TO_BUILD ?? '')
+	$effect(() => {
+		selectedBuilding = data.civilization.config?.NEXT_BUILDING_TO_BUILD ?? ''
+	})
+	let savingBuilding = $state(false)
+
+	const selectedBuildingInfo = $derived.by(() => {
+		if (!selectedBuilding) return null
+		const meta = BUILDING_CLASSES[selectedBuilding as BuildingTypes]
+		if (!meta) return null
+		return {
+			costs: meta.constructionCosts ?? [],
+			workers: meta.workerRequiredToBuild ?? [],
+			timeToBuild: meta.timeToBuild
+		}
+	})
 
 	// ── Stat helpers ──────────────────────────────────────────────────────────
 	const fmt = (n: number) => Math.round(n).toLocaleString('fr-FR')
@@ -873,6 +940,84 @@
 				<Hammer size="18" style="color:oklch(0.5 0.1 50); flex-shrink:0;" />
 				<h2 class="civ-section-title" style="margin:0;">Constructions en cours ({pendingConstructions.length} au total)</h2>
 			</div>
+
+			<!-- Choix du prochain bâtiment à construire -->
+			<form
+				method="post"
+				action="?/updateNextBuilding"
+				use:enhance={() => {
+					savingBuilding = true
+					return async ({ result, update }) => {
+						savingBuilding = false
+						if (result.type === 'success') {
+							toast.success('Prochain bâtiment mis à jour')
+							await update()
+						} else if (result.type === 'failure') {
+							toast.error((result.data?.message as string) ?? 'Une erreur est survenue')
+						} else {
+							await update()
+						}
+					}
+				}}
+				style="margin-top:12px; padding:14px 16px; border-radius:4px; background:oklch(0.97 0.01 84); border:1px solid oklch(0.83 0.04 70); display:flex; flex-direction:column; gap:10px;"
+			>
+				<label for="nextBuildingToBuild" style="font-family:'Marcellus',serif; font-size:15px; color:oklch(0.35 0.04 40);">Prochain bâtiment à construire</label>
+				<div style="display:flex; flex-wrap:wrap; gap:10px; align-items:center;">
+					<select
+						id="nextBuildingToBuild"
+						name="nextBuildingToBuild"
+						bind:value={selectedBuilding}
+						class="select select-bordered"
+						style="flex:1; min-width:220px;"
+					>
+						<option value="">Aucun</option>
+						{#each Object.values(BuildingTypes) as buildingType}
+							{@const lockedBy = lockedBuildings.get(buildingType)}
+							<option
+								value={buildingType}
+								disabled={!!lockedBy}
+								title={lockedBy ? `Recherche manquante : ${lockedBy}` : undefined}
+							>{buildingNames[buildingType]}{lockedBy ? ` 🔒 (recherche : ${lockedBy})` : ''}</option>
+						{/each}
+					</select>
+					<button
+						type="submit"
+						disabled={savingBuilding}
+						style="padding:10px 18px; border:none; border-radius:4px; background:oklch(0.5 0.13 34); color:oklch(0.95 0.02 84); font-family:'Marcellus',serif; font-size:15px; cursor:pointer; box-shadow:0 4px 12px rgba(80,30,20,.24); opacity:{savingBuilding ? 0.6 : 1};"
+					>{savingBuilding ? 'Enregistrement…' : 'Enregistrer'}</button>
+				</div>
+				<p style="font-size:13px; color:oklch(0.5 0.03 50); margin:0;">Bâtiment que la civilisation cherchera à construire en priorité.</p>
+				{#if selectedBuildingInfo}
+					<div style="padding:12px 14px; border:1px solid oklch(0.8 0.04 70); border-radius:4px; background:oklch(0.95 0.018 84); display:flex; flex-direction:column; gap:10px;">
+						<div style="display:flex; align-items:baseline; gap:8px;">
+							<span style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50);">Temps de construction</span>
+							<span style="font-size:15px; font-weight:600; color:oklch(0.32 0.04 40);">{selectedBuildingInfo.timeToBuild ?? '?'} mois</span>
+						</div>
+						<div>
+							<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Ressources requises</div>
+							{#if selectedBuildingInfo.costs.length}
+								<div style="display:flex; flex-wrap:wrap; gap:6px;">
+									{#each selectedBuildingInfo.costs as cost}
+										<span style="font-size:14px; padding:3px 10px; border-radius:3px; background:oklch(0.92 0.03 78); color:oklch(0.35 0.04 42);">{cost.amount} {resourceNames[cost.resource]}</span>
+									{/each}
+								</div>
+							{:else}
+								<span style="font-size:14px; color:oklch(0.5 0.03 50);">Aucune ressource requise</span>
+							{/if}
+						</div>
+						{#if selectedBuildingInfo.workers.length}
+							<div>
+								<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Ouvriers requis pour la construction</div>
+								<div style="display:flex; flex-wrap:wrap; gap:6px;">
+									{#each selectedBuildingInfo.workers as worker}
+										<span style="font-size:14px; padding:3px 10px; border-radius:3px; background:oklch(0.92 0.03 78); color:oklch(0.35 0.04 42);">{worker.amount} {OCCUPATIONS[worker.occupation]}</span>
+									{/each}
+								</div>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</form>
 
 			{#if pendingGroups.length === 0}
 				<p style="color:oklch(0.55 0.03 50); font-size:15px; font-style:italic; margin-top:8px;">Aucune construction en cours pour le moment.</p>

--- a/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
+++ b/apps/front/src/routes/my-civilizations/[slug]/config/+page.svelte
@@ -17,23 +17,6 @@
 	import { toast } from 'svelte-sonner'
 
 	type ConfigFormData = z.infer<typeof civilizationConfigSchema>
-	import {
-		BuildingTypes,
-		House,
-		Farm,
-		Kiln,
-		Sawmill,
-		Mine,
-		Campfire,
-		Cache,
-		Wall,
-		Library,
-		getBuildingGate,
-		getTechNode,
-		type ResourceTypes,
-		type OccupationTypes
-	} from '@ajustor/simulation'
-	import { buildingNames, resourceNames, OCCUPATIONS } from '$lib/translations'
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte'
 
 	interface Props {
@@ -61,6 +44,11 @@
 		}
 	})
 
+	// Note : le choix du prochain bâtiment à construire a été déplacé vers le bloc
+	// « Constructions en cours » de la page de civilisation. Le champ
+	// `nextBuildingToBuild` reste néanmoins dans le formulaire (chargé puis
+	// réémis tel quel) afin que l'enregistrement de cette page ne l'efface pas.
+
 	const { form: formData, enhance: formEnhance } = form
 
 	const toggleExchange = (civilizationId: string, checked: boolean | 'indeterminate') => {
@@ -81,49 +69,6 @@
 		}
 	}
 
-	// Construction requirements come from the static fields on each building class.
-	type BuildingMeta = {
-		constructionCosts?: { resource: ResourceTypes; amount: number }[]
-		workerRequiredToBuild?: { occupation: OccupationTypes; amount: number }[]
-		timeToBuild?: number
-	}
-	const BUILDING_CLASSES: Record<BuildingTypes, BuildingMeta> = {
-		[BuildingTypes.HOUSE]: House,
-		[BuildingTypes.FARM]: Farm,
-		[BuildingTypes.KILN]: Kiln,
-		[BuildingTypes.SAWMILL]: Sawmill,
-		[BuildingTypes.MINE]: Mine,
-		[BuildingTypes.CAMPFIRE]: Campfire,
-		[BuildingTypes.CACHE]: Cache,
-		[BuildingTypes.WALL]: Wall,
-		[BuildingTypes.LIBRARY]: Library
-	}
-
-	// Bâtiments verrouillés par l'arbre de technologies : pour chaque type gardé
-	// par une techno non encore recherchée, on garde le nom (FR) de cette techno.
-	const researchedTechs = $derived<string[]>(data.civilization.researchedTechs ?? [])
-	const lockedBuildings = $derived.by(() => {
-		const locked = new Map<BuildingTypes, string>()
-		for (const buildingType of Object.values(BuildingTypes)) {
-			const gate = getBuildingGate(buildingType)
-			if (gate && !researchedTechs.includes(gate)) {
-				locked.set(buildingType, getTechNode(gate)?.name ?? gate)
-			}
-		}
-		return locked
-	})
-
-	const selectedBuildingInfo = $derived.by(() => {
-		const type = $formData.nextBuildingToBuild
-		if (!type) return null
-		const meta = BUILDING_CLASSES[type as BuildingTypes]
-		if (!meta) return null
-		return {
-			costs: meta.constructionCosts ?? [],
-			workers: meta.workerRequiredToBuild ?? [],
-			timeToBuild: meta.timeToBuild
-		}
-	})
 </script>
 
 <svelte:head>
@@ -234,69 +179,7 @@
 				</div>
 			</div>
 
-			<!-- Construction -->
-			<div class="civ-inner-card">
-				<h3 class="civ-section-title">Construction</h3>
-				<div style="display:flex; flex-direction:column; gap:16px;">
-				<FormField {form} name="nextBuildingToBuild">
-					<FormControl>
-						{#snippet children({ props })}
-							<FormLabel>Prochain bâtiment à construire</FormLabel>
-							<select
-								{...props}
-								value={$formData.nextBuildingToBuild ?? ''}
-								onchange={(e) => { $formData.nextBuildingToBuild = e.currentTarget.value || null }}
-								class="select select-bordered w-full"
-							>
-								<option value="">Aucun</option>
-								{#each Object.values(BuildingTypes) as buildingType}
-									{@const lockedBy = lockedBuildings.get(buildingType)}
-									<option
-										value={buildingType}
-										disabled={!!lockedBy}
-										title={lockedBy ? `Recherche manquante : ${lockedBy}` : undefined}
-									>{buildingNames[buildingType]}{lockedBy ? ` 🔒 (recherche : ${lockedBy})` : ''}</option>
-								{/each}
-							</select>
-						{/snippet}
-					</FormControl>
-					<FormDescription>Bâtiment que la civilisation cherchera à construire en priorité.</FormDescription>
-					{#if selectedBuildingInfo}
-						<div style="margin-top:10px; padding:12px 14px; border:1px solid oklch(0.8 0.04 70); border-radius:4px; background:oklch(0.97 0.015 84); display:flex; flex-direction:column; gap:10px;">
-							<div style="display:flex; align-items:baseline; gap:8px;">
-								<span style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50);">Temps de construction</span>
-								<span style="font-size:15px; font-weight:600; color:oklch(0.32 0.04 40);">{selectedBuildingInfo.timeToBuild ?? '?'} mois</span>
-							</div>
-							<div>
-								<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Ressources requises</div>
-								{#if selectedBuildingInfo.costs.length}
-									<div style="display:flex; flex-wrap:wrap; gap:6px;">
-										{#each selectedBuildingInfo.costs as cost}
-											<span style="font-size:14px; padding:3px 10px; border-radius:3px; background:oklch(0.92 0.03 78); color:oklch(0.35 0.04 42);">{cost.amount} {resourceNames[cost.resource]}</span>
-										{/each}
-									</div>
-								{:else}
-									<span style="font-size:14px; color:oklch(0.5 0.03 50);">Aucune ressource requise</span>
-								{/if}
-							</div>
-							{#if selectedBuildingInfo.workers.length}
-								<div>
-									<div style="font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:oklch(0.52 0.05 50); margin-bottom:4px;">Ouvriers requis pour la construction</div>
-									<div style="display:flex; flex-wrap:wrap; gap:6px;">
-										{#each selectedBuildingInfo.workers as worker}
-											<span style="font-size:14px; padding:3px 10px; border-radius:3px; background:oklch(0.92 0.03 78); color:oklch(0.35 0.04 42);">{worker.amount} {OCCUPATIONS[worker.occupation]}</span>
-										{/each}
-									</div>
-								</div>
-							{/if}
-						</div>
-					{/if}
-					<FormFieldErrors />
-				</FormField>
-			</div>
-		</div>
-
-		<button type="submit" style="align-self:flex-start; padding:12px 22px; border:none; border-radius:4px; background:oklch(0.5 0.13 34); color:oklch(0.95 0.02 84); font-family:'Marcellus',serif; font-size:17px; cursor:pointer; box-shadow:0 4px 12px rgba(80,30,20,.24);">Enregistrer la configuration</button>
+			<button type="submit" style="align-self:flex-start; padding:12px 22px; border:none; border-radius:4px; background:oklch(0.5 0.13 34); color:oklch(0.95 0.02 84); font-family:'Marcellus',serif; font-size:17px; cursor:pointer; box-shadow:0 4px 12px rgba(80,30,20,.24);">Enregistrer la configuration</button>
 	</form>
 </div>
 </div>


### PR DESCRIPTION
## Contexte

Deux demandes des joueurs :
1. Informer les joueurs des dernières mises à jour.
2. Rendre le choix du prochain bâtiment à construire plus accessible, sans avoir à passer par les réglages.

## Changements

### 📰 Page de journal des mises à jour
- Nouvelle route `/changelog` qui présente, par date, les nouveautés / améliorations / corrections du jeu.
- Le contenu est piloté par un module dédié `src/lib/changelog.ts` (facile à enrichir : ajouter une entrée en haut de la liste).
- Lien **« Mises à jour »** ajouté à la navigation (desktop + mobile) dans `Header.svelte`.

### 🔨 Choix du prochain bâtiment déplacé
- Le sélecteur « Prochain bâtiment à construire » (avec l'aperçu coûts / ouvriers / temps de construction et le verrouillage par technologie) est désormais affiché directement dans le bloc **« Constructions en cours »** de la page de civilisation.
- Enregistrement via une action serveur dédiée `updateNextBuilding` (mise à jour partielle de la config), avec retour visuel (toast) et rafraîchissement des données.
- Retiré de la page de configuration. Le champ `nextBuildingToBuild` reste néanmoins transmis par le formulaire de configuration (chargé puis réémis tel quel) afin que l'enregistrement des autres réglages ne l'efface pas.

## Vérifications
- `svelte-check` : aucune nouvelle erreur introduite (les erreurs restantes — `PUBLIC_BACK_URL`, page `colonize` — sont préexistantes et liées à l'environnement de check).
- Prettier appliqué sur les nouveaux fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7Z9gwPCtPFsvoWRw9scrT)_